### PR TITLE
fix(pages): fix bottom navigation bar style in Settings

### DIFF
--- a/src/app/(setting)/_layout.tsx
+++ b/src/app/(setting)/_layout.tsx
@@ -18,7 +18,10 @@ export default function Layout() {
   );
 
   return (
-    <SafeAreaView edges={['bottom']} style={[styles.container]}>
+    <SafeAreaView
+      edges={['bottom']}
+      style={[styles.container, currentStyle?.background_style]}
+    >
       <Stack
         screenOptions={{
           contentStyle:


### PR DESCRIPTION
The SafeAreaView container has no background style, so it defaults to white. Just add a background style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 样式
  - 设置页布局现支持随当前主题自动应用背景样式，深浅色等主题切换时界面更协调、一致。
  - 不影响现有边距与导航行为，保持原有交互与布局稳定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->