### PR TITLE
feat(pages): implement grid order management with zustand

### DIFF
--- a/src/components/modal/types.ts
+++ b/src/components/modal/types.ts
@@ -29,8 +29,7 @@ export interface ModalProps extends PortalBaseProps {
 }
 
 export interface ModalTriggerProps
-  extends ViewProps,
-    Omit<ModalProps, 'visible'> {
+  extends ViewProps, Omit<ModalProps, 'visible'> {
   onPress?: () => void;
   triggerComponent?: ReactElement;
 }

--- a/src/modules/mainPage/index.tsx
+++ b/src/modules/mainPage/index.tsx
@@ -1,8 +1,6 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import useGridOrder from '@/store/gridOrder';
 import * as Haptics from 'expo-haptics';
 import { useRouter } from 'expo-router';
-import React, { FC, memo, useEffect, useLayoutEffect, useState } from 'react';
+import { FC, memo, useEffect, useState } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import { DraggableGrid } from 'react-native-draggable-grid';
 import Carousel from 'react-native-reanimated-carousel';
@@ -12,9 +10,9 @@ import Skeleton from '@/components/skeleton';
 import Text from '@/components/text';
 import ThemeChangeView from '@/components/view';
 
+import useGridOrder from '@/store/gridOrder';
 import useVisualScheme from '@/store/visualScheme';
 
-import { mainPageApplications } from '@/constants/mainPageApplications';
 import { queryBanners } from '@/request/api';
 import { keyGenerator, percent2px } from '@/utils';
 import { openBrowser } from '@/utils/handleOpenURL';
@@ -30,7 +28,6 @@ const IndexPage: FC = () => {
     }[]
   >([]);
   const currentStyle = useVisualScheme(state => state.currentStyle);
-  // const [data, setData] = useState<MainPageGridDataType[]>(mainPageApplications);
 
   const gridData = useGridOrder(state => state.gridData);
   const updateGridOrder = useGridOrder(state => state.updateGridOrder);

--- a/src/types/FeedIconTypes.ts
+++ b/src/types/FeedIconTypes.ts
@@ -3,8 +3,10 @@ import { ImageSourcePropType } from 'react-native';
 
 import { SinglePageType } from './tabBarTypes';
 
-export interface FeedIconTypes
-  extends Omit<SinglePageType, 'iconName' | 'headerLeft'> {
+export interface FeedIconTypes extends Omit<
+  SinglePageType,
+  'iconName' | 'headerLeft'
+> {
   name: string;
   imageUrl: ImageSourcePropType;
   text: string;

--- a/src/types/mainPageGridTypes.ts
+++ b/src/types/mainPageGridTypes.ts
@@ -4,8 +4,10 @@ import { SvgProps } from 'react-native-svg';
 
 import { SinglePageType } from '@/types/tabBarTypes';
 
-export interface MainPageGridDataType
-  extends Omit<SinglePageType, 'iconName' | 'headerLeft'> {
+export interface MainPageGridDataType extends Omit<
+  SinglePageType,
+  'iconName' | 'headerLeft'
+> {
   imageUrl: ImageSourcePropType | React.FC<SvgProps>;
   href?: Href;
   action?: () => void;

--- a/src/types/settingItem.ts
+++ b/src/types/settingItem.ts
@@ -2,8 +2,10 @@ import { Href } from 'expo-router';
 
 import { SinglePageType } from '@/types/tabBarTypes';
 
-export interface SettingItem
-  extends Omit<SinglePageType, 'iconName' | 'headerLeft'> {
+export interface SettingItem extends Omit<
+  SinglePageType,
+  'iconName' | 'headerLeft'
+> {
   id: number;
   icon: { uri: string };
   text: string;


### PR DESCRIPTION
加了个 zustand persist中间件,提升首页图标加载速度,同时避免闪屏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 引入可持久化的主页网格顺序管理，支持保存、恢复与重置自定义顺序，并能合并新增项。

* **性能改进**
  * 移除加载骨架，网格项直接渲染，提升页面加载与交互响应速度。

* **功能改进**
  * 拖拽释放后即时更新并持久化网格顺序，界面数据来源改为集中存储以保证一致性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->