### PR TITLE
refactor(tabs): 将 Tabs 从 AntDesignRN 迁移到 ReactNativeElementUI

### DIFF
--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -46,20 +46,7 @@ export const TabBar: React.FC<TabBarProps> = ({
   const themeName = useVisualScheme(state => state.themeName);
   const [activeIndex, setActiveIndex] = useState(0);
 
-  // 解包 children（如果包含 Fragment 或数组）
-  const childArray = React.useMemo(() => {
-    const rawChildren = React.Children.toArray(children);
-    if (
-      rawChildren.length === 1 &&
-      React.isValidElement(rawChildren[0]) &&
-      rawChildren[0].type === React.Fragment
-    ) {
-      return React.Children.toArray(
-        (rawChildren[0].props as { children?: React.ReactNode }).children
-      );
-    }
-    return rawChildren;
-  }, [children]);
+  const childArray = React.Children.toArray(children);
 
   const tabCount = tabs?.length || childArray.length || 1;
 

--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -1,5 +1,5 @@
 import { Tab, TabView } from '@rneui/themed';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   StyleProp,
   StyleSheet,
@@ -47,6 +47,12 @@ export const TabBar: React.FC<TabBarProps> = ({
   const [activeIndex, setActiveIndex] = useState(0);
   const tabCount = tabs?.length || 1;
 
+  useEffect(() => {
+    setActiveIndex(prev => Math.min(prev, tabCount - 1));
+  }, [tabCount]);
+
+  const clampedActiveIndex = Math.min(activeIndex, tabCount - 1);
+
   const handleChange = (index: number) => {
     const safeIndex = Math.min(Math.max(index, 0), tabCount - 1);
     setActiveIndex(safeIndex);
@@ -77,7 +83,7 @@ export const TabBar: React.FC<TabBarProps> = ({
   return (
     <View style={[styles.container, style]}>
       <Tab
-        value={activeIndex}
+        value={clampedActiveIndex}
         onChange={handleChange}
         variant="default"
         style={{
@@ -95,7 +101,7 @@ export const TabBar: React.FC<TabBarProps> = ({
         ))}
       </Tab>
       <TabView
-        value={activeIndex}
+        value={clampedActiveIndex}
         onChange={handleChange}
         disableSwipe={!swipeable}
         containerStyle={styles.tabView}

--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -22,12 +22,17 @@ import useVisualScheme from '@/store/visualScheme';
  * @param props.children - Tab内容
  * @param props.renderTabBar - 自定义TabBar渲染函数，默认使用DefaultTabBar
  */
+export interface TabData {
+  title: string;
+  key?: string;
+}
+
 export interface TabBarProps {
-  tabs?: Array<{ title: string; key?: string }>;
+  tabs?: TabData[];
   children?: React.ReactNode;
   style?: StyleProp<ViewStyle>;
   swipeable?: boolean;
-  onChange?: (index: number) => void;
+  onChange?: (tab: TabData | undefined, index: number) => void;
 }
 
 export const TabBar: React.FC<TabBarProps> = ({
@@ -40,11 +45,12 @@ export const TabBar: React.FC<TabBarProps> = ({
   const currentStyle = useVisualScheme(state => state.currentStyle);
   const themeName = useVisualScheme(state => state.themeName);
   const [activeIndex, setActiveIndex] = useState(0);
-  const tabCount = tabs?.length || React.Children.count(children) || 2;
+  const tabCount = tabs?.length || 1;
 
   const handleChange = (index: number) => {
-    setActiveIndex(index);
-    onChange?.(index);
+    const safeIndex = Math.min(Math.max(index, 0), tabCount - 1);
+    setActiveIndex(safeIndex);
+    onChange?.(tabs?.[safeIndex], safeIndex);
   };
 
   const getIndicatorStyle = () => {

--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -1,12 +1,18 @@
-import { Tabs, TabsProps } from '@ant-design/react-native';
-import React from 'react';
+import { Tab, TabView } from '@rneui/themed';
+import React, { useState } from 'react';
+import {
+  StyleProp,
+  StyleSheet,
+  TextStyle,
+  View,
+  ViewStyle,
+} from 'react-native';
 
 import useVisualScheme from '@/store/visualScheme';
 
 /**
  * TabBar组件
- * 对AntD Tabs的二次封装，基本使用方法与AntD Tabs一致
- * 主要添加了默认样式配置:
+ * 对RNEUI Tab + TabView 的二次封装，基本使用方法与原AntD Tabs一致
  * - 字体大小18px，字重500
  * - 激活状态文字颜色为紫色(#9379F6)
  * - 下划线样式为紫色，宽度30%，左右margin 10%
@@ -16,13 +22,32 @@ import useVisualScheme from '@/store/visualScheme';
  * @param props.children - Tab内容
  * @param props.renderTabBar - 自定义TabBar渲染函数，默认使用DefaultTabBar
  */
-export const TabBar: React.FC<TabsProps> = props => {
+export interface TabBarProps {
+  tabs?: Array<{ title: string; key?: string }>;
+  children?: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+  swipeable?: boolean;
+  onChange?: (index: number) => void;
+}
+
+export const TabBar: React.FC<TabBarProps> = ({
+  tabs,
+  children,
+  style,
+  swipeable = true,
+  onChange,
+}) => {
   const currentStyle = useVisualScheme(state => state.currentStyle);
   const themeName = useVisualScheme(state => state.themeName);
-  const tabCount =
-    props.tabs?.length || React.Children.count(props.children) || 2;
+  const [activeIndex, setActiveIndex] = useState(0);
+  const tabCount = tabs?.length || React.Children.count(children) || 2;
 
-  const getUnderlineStyle = () => {
+  const handleChange = (index: number) => {
+    setActiveIndex(index);
+    onChange?.(index);
+  };
+
+  const getIndicatorStyle = () => {
     const singleTabWidth = 100 / tabCount;
     const underlineWidth = singleTabWidth * 0.65;
     const margin = (singleTabWidth - underlineWidth) / 2;
@@ -32,39 +57,52 @@ export const TabBar: React.FC<TabsProps> = props => {
       marginHorizontal: `${margin}%`,
       width: `${underlineWidth}%`,
       height: 3,
+      //下划线绝对定位，从第一个tab开始
+      left: 0,
     } as const;
   };
 
+  const getTitleStyle = (active: boolean): TextStyle => ({
+    fontSize: 18,
+    fontWeight: 500,
+    color: active ? '#9379F6' : themeName === 'dark' ? '#969696' : '#3D3D3D',
+  });
+
   return (
-    <Tabs
-      styles={{
-        topTabBarSplitLine: { borderBottomWidth: 0 },
-      }}
-      renderTabBar={tabProps => (
-        <Tabs.DefaultTabBar
-          {...tabProps}
-          tabBarTextStyle={{
-            fontSize: 18,
-            fontWeight: 500,
-          }}
-          tabBarInactiveTextColor={themeName === 'dark' ? '#969696' : '#3D3D3D'}
-          tabBarActiveTextColor="#9379F6"
-          tabBarUnderlineStyle={getUnderlineStyle()}
-          tabBarBackgroundColor={
-            currentStyle?.background_style?.backgroundColor as string
-          }
-          styles={{
-            tab: {
-              height: 60,
-            },
-          }}
-        ></Tabs.DefaultTabBar>
-      )}
-      {...props}
-    >
-      {props.children}
-    </Tabs>
+    <View style={[styles.container, style]}>
+      <Tab
+        value={activeIndex}
+        onChange={handleChange}
+        variant="default"
+        style={{
+          backgroundColor: currentStyle?.background_style?.backgroundColor,
+        }}
+        indicatorStyle={getIndicatorStyle()}
+        buttonStyle={{
+          height: 60,
+          backgroundColor: 'transparent',
+        }}
+        titleStyle={getTitleStyle}
+      >
+        {(tabs || []).map(tab => (
+          <Tab.Item key={tab.key ?? tab.title} title={tab.title} />
+        ))}
+      </Tab>
+      <TabView
+        value={activeIndex}
+        onChange={handleChange}
+        disableSwipe={!swipeable}
+        containerStyle={styles.tabView}
+      >
+        {children}
+      </TabView>
+    </View>
   );
 };
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  tabView: { flex: 1 },
+});
 
 export default TabBar;

--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -1,6 +1,9 @@
-import { Tab, TabView } from '@rneui/themed';
+import { Tab } from '@rneui/themed';
 import React, { useEffect, useState } from 'react';
 import {
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  ScrollView,
   StyleProp,
   StyleSheet,
   TextStyle,
@@ -12,15 +15,12 @@ import useVisualScheme from '@/store/visualScheme';
 
 /**
  * TabBar组件
- * 对RNEUI Tab + TabView 的二次封装，基本使用方法与原AntD Tabs一致
+ * 对 RNEUI Tab 的二次封装与切页动画组件
  * - 字体大小18px，字重500
  * - 激活状态文字颜色为紫色(#9379F6)
  * - 下划线样式为紫色，宽度30%，左右margin 10%
  * - 背景色跟随主题
  * - Tab高度固定为60px
- * @param props - TabsProps类型，继承自AntD Tabs的所有属性
- * @param props.children - Tab内容
- * @param props.renderTabBar - 自定义TabBar渲染函数，默认使用DefaultTabBar
  */
 export interface TabData {
   title: string;
@@ -45,7 +45,23 @@ export const TabBar: React.FC<TabBarProps> = ({
   const currentStyle = useVisualScheme(state => state.currentStyle);
   const themeName = useVisualScheme(state => state.themeName);
   const [activeIndex, setActiveIndex] = useState(0);
-  const tabCount = tabs?.length || 1;
+
+  // 解包 children（如果包含 Fragment 或数组）
+  const childArray = React.useMemo(() => {
+    const rawChildren = React.Children.toArray(children);
+    if (
+      rawChildren.length === 1 &&
+      React.isValidElement(rawChildren[0]) &&
+      rawChildren[0].type === React.Fragment
+    ) {
+      return React.Children.toArray(
+        (rawChildren[0].props as { children?: React.ReactNode }).children
+      );
+    }
+    return rawChildren;
+  }, [children]);
+
+  const tabCount = tabs?.length || childArray.length || 1;
 
   useEffect(() => {
     setActiveIndex(prev => Math.min(prev, tabCount - 1));
@@ -69,7 +85,6 @@ export const TabBar: React.FC<TabBarProps> = ({
       marginHorizontal: `${margin}%`,
       width: `${underlineWidth}%`,
       height: 3,
-      //下划线绝对定位，从第一个tab开始
       left: 0,
     } as const;
   };
@@ -100,21 +115,135 @@ export const TabBar: React.FC<TabBarProps> = ({
           <Tab.Item key={tab.key ?? tab.title} title={tab.title} />
         ))}
       </Tab>
-      <TabView
+      <CustomTabView
         value={clampedActiveIndex}
         onChange={handleChange}
         disableSwipe={!swipeable}
-        containerStyle={styles.tabView}
       >
-        {children}
-      </TabView>
+        {childArray}
+      </CustomTabView>
+    </View>
+  );
+};
+
+/**
+ * CustomTabView 组件
+ *
+ * 【设计说明与手势冲突解决】
+ * 1. 背景问题：
+ *    之前采用 PanResponder 实现切页时，iOS 原生 Stack 导航手势（UIScreenEdgePanGestureRecognizer）
+ *    会在用户从左往右滑动（处于非首 Tab 视图试图滑回左侧 Tab 时）直接抢占手势并触发页面 Stack Pop（返回上一页）。
+ * 2. 解决方案：
+ *    重构为原生水平 ScrollView (horizontal + pagingEnabled)。在 iOS UIKit 中，当 UIScrollView 处于
+ *    非 0 偏移量时，UIKit 手势协商机制会将水平滑动优先分配给 UIScrollView，从而防止误触 iOS 原生 Stack 的侧滑返回。
+ * 3. 交互与同步控制：
+ *    - 点击 Tab 头切换：通过 useEffect 监听 value 变化并调用 scrollViewRef.current.scrollTo(...) 动效切页；
+ *    - 手势滑动切换：监听 onMomentumScrollEnd 与 onScrollEndDrag 两个事件，准确捕捉快滑与慢拖结束时的偏移量并回调 onChange；
+ *    - 手势禁用：支持 scrollEnabled={!disableSwipe}，在页面内有 Slider 等横向手势冲突控件时可动态关闭 ScrollView 滑动。
+ */
+interface CustomTabViewProps {
+  value: number;
+  onChange: (index: number) => void;
+  disableSwipe?: boolean;
+  children: React.ReactNode[];
+}
+
+const CustomTabView: React.FC<CustomTabViewProps> = ({
+  value,
+  onChange,
+  disableSwipe = false,
+  children,
+}) => {
+  const [containerWidth, setContainerWidth] = useState(0);
+  const scrollViewRef = React.useRef<ScrollView>(null);
+  const currentIndex = React.useRef(value);
+  const currentX = React.useRef(0);
+  const isInitialRender = React.useRef(true);
+
+  const childCount = children.length;
+
+  // 保持 currentIndex 引用最新，避免闭包捕获旧值
+  useEffect(() => {
+    currentIndex.current = value;
+  }, [value]);
+
+  // 当外部选中的 activeIndex (value) 变化时，驱动 ScrollView 滚动到对应页面
+  useEffect(() => {
+    if (containerWidth > 0 && scrollViewRef.current) {
+      const targetX = value * containerWidth;
+      if (isInitialRender.current) {
+        // 首次布局完成，无动画直接定位到初始页
+        isInitialRender.current = false;
+        scrollViewRef.current.scrollTo({ x: targetX, animated: false });
+        currentX.current = targetX;
+      } else if (Math.abs(currentX.current - targetX) > 5) {
+        // 仅在当前滚动位置与目标位置差距大于 5px 时执行动画，避免手动滑动完成后触发二次冗余滚动动画
+        scrollViewRef.current.scrollTo({ x: targetX, animated: true });
+        currentX.current = targetX;
+      }
+    }
+  }, [value, containerWidth]);
+
+  /**
+   * 滑动结束处理逻辑（兼容惯性结束与无惯性慢速拖拽结束）
+   */
+  const handleScrollEnd = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    if (containerWidth <= 0) return;
+    const offsetX = e.nativeEvent.contentOffset.x;
+    currentX.current = offsetX;
+    const newIndex = Math.round(offsetX / containerWidth);
+    const clampedIndex = Math.min(Math.max(newIndex, 0), childCount - 1);
+
+    if (clampedIndex !== currentIndex.current) {
+      currentIndex.current = clampedIndex;
+      onChange(clampedIndex);
+    }
+  };
+
+  return (
+    <View
+      style={styles.tabViewContainer}
+      onLayout={e => {
+        const width = e.nativeEvent.layout.width;
+        if (width > 0 && width !== containerWidth) {
+          setContainerWidth(width);
+        }
+      }}
+    >
+      {containerWidth > 0 && (
+        <ScrollView
+          ref={scrollViewRef}
+          horizontal
+          pagingEnabled
+          scrollEnabled={!disableSwipe}
+          showsHorizontalScrollIndicator={false}
+          showsVerticalScrollIndicator={false}
+          bounces={false}
+          directionalLockEnabled
+          onMomentumScrollEnd={handleScrollEnd}
+          onScrollEndDrag={handleScrollEnd}
+          style={styles.scrollView}
+          contentContainerStyle={{ width: containerWidth * childCount }}
+        >
+          {children.map((child, index) => (
+            <View
+              key={index}
+              style={[styles.tabViewPage, { width: containerWidth }]}
+            >
+              {child}
+            </View>
+          ))}
+        </ScrollView>
+      )}
     </View>
   );
 };
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  tabView: { flex: 1 },
+  tabViewContainer: { flex: 1, overflow: 'hidden' },
+  scrollView: { flex: 1 },
+  tabViewPage: { flex: 1 },
 });
 
 export default TabBar;


### PR DESCRIPTION
- `src/components/tabs/index.tsx`：封装层从 AntD `Tabs` + `Tabs.DefaultTabBar` 迁移到 RNEUI `Tab` + `Tab.Item` + `TabView`
- 对外 API 保持兼容（`tabs` / `children` / `style` / `swipeable` / `onChange`），调用方无需修改
- 新增 `activeIndex` 状态，同步标题栏切换与内容滑动
- 样式保持一致：字体 18px / 字重 500、激活文字 `#9379F6`、未激活文字按主题、下划线高 3 宽为单个 tab 的 65%、Tab 高度 60、背景跟随主题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 重构标签栏交互，支持点击切换与手势滑动切换。
  * 支持自定义标签内容、样式及滑动开关。
  * 标签页内容与当前选中标签保持同步，切换状态更加稳定。
  * 新增标签切换回调，便于及时响应当前标签变化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->