### PR TITLE
fix(course): improve timetable resilience and cache migration

### DIFF
--- a/src/components/CourseTableErrorBoundary.tsx
+++ b/src/components/CourseTableErrorBoundary.tsx
@@ -1,0 +1,57 @@
+import { Button } from '@ant-design/react-native';
+import React from 'react';
+import { Text, View } from 'react-native';
+
+import { log } from '@/utils/logger';
+
+interface Props {
+  children: React.ReactNode;
+  onReset?: () => void;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export default class CourseTableErrorBoundary extends React.Component<
+  Props,
+  State
+> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    log.error('课表渲染异常:', error, info.componentStack);
+  }
+
+  render() {
+    if (!this.state.error) return this.props.children;
+
+    return (
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 24,
+          gap: 12,
+        }}
+      >
+        <Text>课表解析异常</Text>
+        <Text>已保护其他页面，你可以重新加载课表。</Text>
+        <Button
+          type="primary"
+          onPress={() => {
+            this.setState({ error: null });
+            this.props.onReset?.();
+          }}
+        >
+          重新加载
+        </Button>
+      </View>
+    );
+  }
+}

--- a/src/modules/courseTable/components/CourseDataForm.tsx
+++ b/src/modules/courseTable/components/CourseDataForm.tsx
@@ -36,7 +36,7 @@ interface CourseFormProps {
   pageText: string;
   mode?: 'create' | 'edit';
   onSuccess?: () => void;
-  onSubmit?: (data: CourseFormData) => Promise<void>;
+  onSubmit?: (_data: CourseFormData) => Promise<void>;
   courseData?: courseType;
 }
 
@@ -46,16 +46,25 @@ export const CourseDataForm = (props: CourseFormProps) => {
   const currentStyle = useVisualScheme(state => state.currentStyle);
   const { semester, year } = useTimeStore();
   const { addCourse: addCourseToStore } = useCourse();
+  const calendarWeekCount = useTimeStore(state => state.getSemesterWeekCount());
+  const maxCachedWeek = useCourse(state =>
+    state.courses.reduce(
+      (maximum, course) => Math.max(maximum, ...course.weeks),
+      0
+    )
+  );
+  const pickerWeekCount = Math.max(18, calendarWeekCount, maxCachedWeek);
+  const defaultWeeks = React.useMemo(
+    () => Array.from({ length: pickerWeekCount }, (_, index) => index + 1),
+    [pickerWeekCount]
+  );
 
   const [formData, setFormData] = React.useState<CourseFormData>(() => {
     if (props.courseData) {
       const cd = props.courseData;
       return {
         name: cd.classname || '',
-        weeks:
-          cd.weeks && cd.weeks.length > 0
-            ? cd.weeks
-            : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+        weeks: cd.weeks && cd.weeks.length > 0 ? cd.weeks : defaultWeeks,
         day: cd.day || 1,
         dur_class: cd.class_when || '1-2',
         where: cd.where || '',
@@ -65,7 +74,7 @@ export const CourseDataForm = (props: CourseFormProps) => {
     }
     return {
       name: '',
-      weeks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+      weeks: defaultWeeks,
       day: 1,
       dur_class: '1-2',
       where: '',
@@ -79,10 +88,7 @@ export const CourseDataForm = (props: CourseFormProps) => {
       const cd = props.courseData;
       setFormData({
         name: cd.classname || '',
-        weeks:
-          cd.weeks && cd.weeks.length > 0
-            ? cd.weeks
-            : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+        weeks: cd.weeks && cd.weeks.length > 0 ? cd.weeks : defaultWeeks,
         day: cd.day || 1,
         dur_class: cd.class_when || '1-2',
         where: cd.where || '',
@@ -90,7 +96,7 @@ export const CourseDataForm = (props: CourseFormProps) => {
         credit: cd.credit ?? 3,
       });
     }
-  }, [props.courseData]);
+  }, [defaultWeeks, props.courseData]);
   const [loading, setLoading] = React.useState(false);
 
   const items: FormItem[] = [
@@ -100,7 +106,7 @@ export const CourseDataForm = (props: CourseFormProps) => {
       value:
         formData.weeks.length > 0
           ? `${Math.min(...formData.weeks)}-${Math.max(...formData.weeks)}周`
-          : '1-18周',
+          : `1-${pickerWeekCount}周`,
       type: 'picker',
     },
     {
@@ -151,6 +157,8 @@ export const CourseDataForm = (props: CourseFormProps) => {
       credit: data.credit || 0,
       semester: curSemester,
       year: curYear,
+      note: '',
+      nature: '自定义课程',
       is_official: false, // 自主添加而非教务系统的课
     };
 
@@ -220,9 +228,7 @@ export const CourseDataForm = (props: CourseFormProps) => {
           if (props.mode !== 'edit') {
             setFormData({
               name: '',
-              weeks: [
-                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
-              ],
+              weeks: defaultWeeks,
               day: 1,
               dur_class: '1-2',
               where: '',
@@ -268,18 +274,13 @@ export const CourseDataForm = (props: CourseFormProps) => {
                 item.title === '选择周次' ? (
                   <MultiPicker
                     data={[
-                      [...Array(18).keys()].map(i => ({
+                      [...Array(pickerWeekCount).keys()].map(i => ({
                         value: i + 1,
                         label: `第${i + 1}周`,
                       })),
                     ]}
                     defaultValue={
-                      formData.weeks.length > 0
-                        ? formData.weeks
-                        : [
-                            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-                            16, 17, 18,
-                          ]
+                      formData.weeks.length > 0 ? formData.weeks : defaultWeeks
                     }
                     onConfirm={values => {
                       const selectedWeeks = values.map(v => parseInt(v));

--- a/src/modules/courseTable/components/CourseDataForm.tsx
+++ b/src/modules/courseTable/components/CourseDataForm.tsx
@@ -49,7 +49,8 @@ export const CourseDataForm = (props: CourseFormProps) => {
   const calendarWeekCount = useTimeStore(state => state.getSemesterWeekCount());
   const maxCachedWeek = useCourse(state =>
     state.courses.reduce(
-      (maximum, course) => Math.max(maximum, ...course.weeks),
+      (maximum, course) =>
+        Math.max(maximum, ...(Array.isArray(course.weeks) ? course.weeks : [])),
       0
     )
   );

--- a/src/modules/courseTable/components/ScheduleHeaders.tsx
+++ b/src/modules/courseTable/components/ScheduleHeaders.tsx
@@ -69,15 +69,17 @@ export const ScheduleHeaderTitle: React.FC = () => {
         ]}
       >
         上次更新时间：
-        {new Date(lastUpdate * 1000).toLocaleString('zh-CN', {
-          year: 'numeric',
-          month: '2-digit',
-          day: '2-digit',
-          hour: '2-digit',
-          minute: '2-digit',
-          second: '2-digit',
-          hour12: false,
-        })}
+        {lastUpdate > 0
+          ? new Date(lastUpdate * 1000).toLocaleString('zh-CN', {
+              year: 'numeric',
+              month: '2-digit',
+              day: '2-digit',
+              hour: '2-digit',
+              minute: '2-digit',
+              second: '2-digit',
+              hour12: false,
+            })
+          : '暂无'}
       </Text>
     </View>
   );
@@ -85,7 +87,6 @@ export const ScheduleHeaderTitle: React.FC = () => {
 
 export const ScheduleHeaderRight: React.FC = () => {
   const router = useRouter();
-  const currentStyle = useVisualScheme(state => state.currentStyle);
   return (
     <View
       style={{

--- a/src/modules/courseTable/components/courseTable/CourseContent.tsx
+++ b/src/modules/courseTable/components/courseTable/CourseContent.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/constants/SCHEDULE';
 import useVisualScheme from '@/store/visualScheme';
 import { componentMap } from '@/themeBasedComponents';
+import { parseClassWhen } from '@/utils/courseRuntime';
 
 import ModalContent from './ModalContent';
 import { CourseTransferType, courseType } from './type';
@@ -27,25 +28,24 @@ const CourseContent: React.FC<CourseContentProps> = memo(
     const { class_when, originalData, currentWeek } = props;
 
     const layoutName = useVisualScheme(state => state.layoutName);
-    const CourseItem = componentMap?.[layoutName].CourseItem;
-
-    // 解析课程范围
-    function parseRange(str: string) {
-      const [start, end] = str.split('-').map(Number);
-      return { start, end };
-    }
+    const CourseItem = componentMap?.[layoutName]?.CourseItem;
 
     // 缓存当前的范围
-    const currRange = useMemo(() => parseRange(class_when), [class_when]);
+    const currRange = useMemo(() => parseClassWhen(class_when), [class_when]);
 
     // 现在slotCourses在课表重叠的时候会全包含
     // (比如之前在课程重叠时，点击1-4只包含1-4的信息，现在1-4会额外包含1-2和3-4的信息)
     const slotCourses = useMemo(() => {
       return originalData.filter(c => {
+        if (!currRange) return false;
         if (c.day - 1 !== props.colIndex) return false;
 
-        const { start, end } = parseRange(c.class_when);
-        return !(end < currRange.start || start > currRange.end);
+        const range = parseClassWhen(c.class_when);
+        if (!range) return false;
+        return !(
+          range.endSection < currRange.startSection ||
+          range.startSection > currRange.endSection
+        );
       });
     }, [originalData, props.colIndex, currRange]);
 
@@ -58,13 +58,16 @@ const CourseContent: React.FC<CourseContentProps> = memo(
     );
     const isCoveredAndNotInCurrWeek = useMemo(() => {
       return slotCourses.some(c => {
+        if (!currRange) return false;
         if (c.id === props.id) return false;
 
-        const { start, end } = parseRange(c.class_when);
+        const range = parseClassWhen(c.class_when);
+        if (!range) return false;
         const isFullCovers =
-          start <= currRange.start &&
-          end >= currRange.end &&
-          (start < currRange.start || end > currRange.end);
+          range.startSection <= currRange.startSection &&
+          range.endSection >= currRange.endSection &&
+          (range.startSection < currRange.startSection ||
+            range.endSection > currRange.endSection);
 
         const isCoveringRendered = visibleIdSet.has(c.id); // 覆盖当前课程的课程也必须被显示
         return !props.isThisWeek && isFullCovers && isCoveringRendered;
@@ -83,7 +86,7 @@ const CourseContent: React.FC<CourseContentProps> = memo(
         <ModalContent
           id={c.id}
           class_when={c.class_when}
-          isThisWeek={c.weeks.includes(currentWeek)}
+          isThisWeek={Array.isArray(c.weeks) && c.weeks.includes(currentWeek)}
           courseName={c.classname}
           teacher={c.teacher}
           classroom={c.where}
@@ -94,6 +97,8 @@ const CourseContent: React.FC<CourseContentProps> = memo(
         />
       </View>
     );
+
+    if (!currRange) return null;
 
     return (
       <>

--- a/src/modules/courseTable/components/courseTable/TimetableScrollView.tsx
+++ b/src/modules/courseTable/components/courseTable/TimetableScrollView.tsx
@@ -552,7 +552,11 @@ const styles = StyleSheet.create({
     position: 'relative',
   },
   backgroundLayer: {
-    ...StyleSheet.absoluteFillObject,
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
     zIndex: -1,
   },
   text: {

--- a/src/modules/courseTable/components/courseTable/index.tsx
+++ b/src/modules/courseTable/components/courseTable/index.tsx
@@ -42,6 +42,7 @@ import {
 import useCourseTableAppearance from '@/store/courseTableAppearance';
 import useVisualScheme from '@/store/visualScheme';
 import { commonColors } from '@/styles/common';
+import { parseClassWhen } from '@/utils/courseRuntime';
 import globalEventBus from '@/utils/eventBus';
 import { requestPermission } from '@/utils/requestPermission';
 
@@ -81,7 +82,6 @@ const Schedule: React.FC<CourseTableProps> = ({
   // 完整课表内容的引用
   const fullTableRef = useRef<View>(null);
   // Canvas引用，用于截图背景
-  const canvasRef = useCanvasRef();
   // 合成Canvas引用，用于合成背景和前景
   const compositeCanvasRef = useCanvasRef();
   // 前景截图的Skia Image
@@ -354,58 +354,73 @@ const Schedule: React.FC<CourseTableProps> = ({
     // 先按时间槽和日期分组课程
     const coursesBySlot = new Map();
     const idxMap = new Map<string, number>();
-    data.forEach((course: courseType, idx: number) => {
-      const {
-        id,
-        day,
-        teacher,
-        where,
-        class_when,
-        classname,
-        weeks,
-        week_duration,
-        credit,
-        note,
-        is_official,
-      } = course;
-      idxMap.set(course.id, idx);
-      // 计算课程的时间跨度（占几节课）
-      const timeSpan = class_when
-        .split('-')
-        .map(Number)
-        .reduce((a: number, b: number) => b - a + 1);
-
-      // 计算课程在课表中的位置
-      const rowIndex = Number(class_when.split('-')[0]) - 1; // 第几节课开始
-      const colIndex = day - 1; // 周几（0-6，对应周一到周日）
-      const key = `${rowIndex}-${colIndex}`; // 生成唯一键，标识时间槽位置
-
-      if (rowIndex !== -1 && colIndex !== -1) {
-        // 如果该时间槽还没有课程，创建一个空数组
-        if (!coursesBySlot.has(key)) {
-          coursesBySlot.set(key, []);
-        }
-
-        // 将课程添加到对应的时间槽中
-        coursesBySlot.get(key).push({
+    (Array.isArray(data) ? data : []).forEach(
+      (course: courseType, idx: number) => {
+        const {
           id,
-          courseName: classname,
-          timeSpan,
+          day,
           teacher,
-          date: DAYS_OF_WEEK[colIndex],
-          classroom: where,
-          rowIndex,
-          colIndex,
+          where,
+          class_when,
+          classname,
           weeks,
-          isThisWeek: weeks.includes(currentWeek), // 标记是否为当前周的课程
           week_duration,
           credit,
-          class_when,
           note,
           is_official,
-        });
+        } = course;
+        const parsedRange = parseClassWhen(class_when);
+        const safeDay = Number(day);
+        if (
+          !parsedRange ||
+          !Number.isInteger(safeDay) ||
+          safeDay < 1 ||
+          safeDay > DAYS_OF_WEEK.length
+        ) {
+          return;
+        }
+
+        idxMap.set(course.id, idx);
+        // 计算课程的时间跨度（占几节课）
+        const timeSpan = parsedRange.endSection - parsedRange.startSection + 1;
+
+        // 计算课程在课表中的位置
+        const rowIndex = parsedRange.startSection - 1; // 第几节课开始
+        const colIndex = safeDay - 1; // 周几（0-6，对应周一到周日）
+        const key = `${rowIndex}-${colIndex}`; // 生成唯一键，标识时间槽位置
+
+        if (
+          rowIndex >= 0 &&
+          rowIndex < timetableMatrix.length &&
+          colIndex >= 0 &&
+          colIndex < DAYS_OF_WEEK.length
+        ) {
+          // 如果该时间槽还没有课程，创建一个空数组
+          if (!coursesBySlot.has(key)) {
+            coursesBySlot.set(key, []);
+          }
+
+          // 将课程添加到对应的时间槽中
+          coursesBySlot.get(key).push({
+            id,
+            courseName: classname,
+            timeSpan,
+            teacher,
+            date: DAYS_OF_WEEK[colIndex],
+            classroom: where,
+            rowIndex,
+            colIndex,
+            weeks: Array.isArray(weeks) ? weeks : [],
+            isThisWeek: Array.isArray(weeks) && weeks.includes(currentWeek), // 标记是否为当前周的课程
+            week_duration,
+            credit,
+            class_when,
+            note,
+            is_official,
+          });
+        }
       }
-    });
+    );
 
     // 遍历每个时间槽，选择正确的课程显示
     for (const [key, slotCourses] of coursesBySlot) {
@@ -426,7 +441,10 @@ const Schedule: React.FC<CourseTableProps> = ({
       const courseToShow = sorted[0] ?? null;
 
       if (courseToShow) {
-        timetableMatrix[rowIndex][colIndex] = {
+        const row = timetableMatrix[rowIndex];
+        if (!row || colIndex < 0 || colIndex >= row.length) continue;
+
+        row[colIndex] = {
           classname: courseToShow.courseName,
           timeSpan: courseToShow.timeSpan,
         };

--- a/src/modules/courseTable/components/courseTable/type.ts
+++ b/src/modules/courseTable/components/courseTable/type.ts
@@ -19,7 +19,8 @@ export type courseType = {
   weeks: number[];
   where: string;
   year: string;
-  note?: string; // 添加 note 字段
+  note?: string;
+  nature?: string;
   is_official: boolean; // 是否为教务系统课程
 };
 

--- a/src/modules/courseTable/index.tsx
+++ b/src/modules/courseTable/index.tsx
@@ -8,7 +8,13 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Platform, StyleSheet, Text, TouchableOpacity } from 'react-native';
+import {
+  View as NativeView,
+  Platform,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import CourseTableErrorBoundary from '@/components/CourseTableErrorBoundary';
@@ -400,29 +406,38 @@ const CourseTablePage: FC = () => {
         />
       </CourseTableErrorBoundary>
       {timetableStatus === 'loading' && courses.length === 0 && (
-        <View style={styles.statusBanner}>
+        <NativeView style={[styles.statusBanner, styles.topStatusBanner]}>
           <Text style={styles.statusText}>正在获取课表…</Text>
-        </View>
+        </NativeView>
       )}
-      {timetableStatus === 'stale' && (
-        <View style={styles.statusBanner}>
-          <Text style={styles.statusText}>刷新失败，当前展示本地缓存</Text>
-        </View>
-      )}
-      {timetableStatus === 'error' && courses.length === 0 && (
+      {(timetableStatus === 'stale' ||
+        (timetableStatus === 'error' && courses.length === 0)) && (
         <TouchableOpacity
-          style={styles.statusBanner}
+          accessibilityHint="重新请求当前学期课表"
+          accessibilityLabel="重新加载课表"
+          accessibilityRole="button"
+          activeOpacity={0.8}
+          style={[
+            styles.statusBanner,
+            styles.retryBanner,
+            { bottom: tabbarHeight + 20 },
+          ]}
           onPress={() => {
             void onTimetableRefresh(true).catch(() => undefined);
           }}
         >
-          <Text style={styles.statusText}>课表加载失败，点击重试</Text>
+          <Text style={styles.statusText}>
+            {timetableStatus === 'stale'
+              ? '刷新失败，当前展示本地缓存 · '
+              : '课表加载失败 · '}
+            <Text style={styles.retryText}>点击重试</Text>
+          </Text>
         </TouchableOpacity>
       )}
       {timetableStatus === 'ready' && courses.length === 0 && (
-        <View style={styles.statusBanner}>
+        <NativeView style={[styles.statusBanner, styles.topStatusBanner]}>
           <Text style={styles.statusText}>本学期暂无课程</Text>
-        </View>
+        </NativeView>
       )}
       {showWeekPicker && (
         <WeekSelector
@@ -455,18 +470,29 @@ const CourseTablePage: FC = () => {
 const styles = StyleSheet.create({
   statusBanner: {
     position: 'absolute',
-    top: 12,
     left: 20,
     right: 20,
     zIndex: 200,
     borderRadius: 8,
-    paddingHorizontal: 14,
-    paddingVertical: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
     backgroundColor: 'rgba(40, 40, 40, 0.82)',
+    minHeight: 48,
+    justifyContent: 'center',
+  },
+  topStatusBanner: {
+    top: 12,
+  },
+  retryBanner: {
+    left: 16,
+    right: 16,
   },
   statusText: {
     color: '#FFFFFF',
     textAlign: 'center',
+  },
+  retryText: {
+    fontWeight: '700',
   },
   testButton: {
     position: 'absolute',

--- a/src/modules/courseTable/index.tsx
+++ b/src/modules/courseTable/index.tsx
@@ -30,7 +30,11 @@ import {
 import useCourse from '@/store/course';
 import useTimeStore from '@/store/time';
 import useVisualScheme from '@/store/visualScheme';
-import { CourseDataError, parseCourseTableResponse } from '@/utils/courseData';
+import {
+  CourseDataError,
+  isValidCourseScope,
+  parseCourseTableResponse,
+} from '@/utils/courseData';
 import {
   courseLiveActivity,
   LIVE_ACTIVITY_ENABLED,
@@ -239,6 +243,37 @@ const CourseTablePage: FC = () => {
     [fetchTimetable, semester, year]
   );
 
+  const handleTimetableRetry = useCallback(async () => {
+    setTimetableStatus('refreshing');
+
+    try {
+      const { year: storedYear, semester: storedSemester } =
+        useTimeStore.getState();
+
+      if (!isValidCourseScope(storedYear, storedSemester)) {
+        const currentSemesterInfo = await fetchSemesterInfo();
+        await fetchTimetable(
+          currentSemesterInfo.year,
+          currentSemesterInfo.semester,
+          true
+        );
+        setTimetableStatus('ready');
+        return;
+      }
+
+      await onTimetableRefresh(true);
+    } catch (error) {
+      setTimetableStatus(
+        useCourse.getState().courses.length > 0 ? 'stale' : 'error'
+      );
+      log.error('Failed to retry timetable:', error);
+      Toast.show({
+        text: getTimetableErrorMessage(error),
+        icon: 'fail',
+      });
+    }
+  }, [fetchSemesterInfo, fetchTimetable, onTimetableRefresh]);
+
   const handleApply = useCallback(
     async ({
       year: newYear,
@@ -423,7 +458,7 @@ const CourseTablePage: FC = () => {
             { bottom: tabbarHeight + 20 },
           ]}
           onPress={() => {
-            void onTimetableRefresh(true).catch(() => undefined);
+            void handleTimetableRetry();
           }}
         >
           <Text style={styles.statusText}>

--- a/src/modules/courseTable/index.tsx
+++ b/src/modules/courseTable/index.tsx
@@ -5,11 +5,14 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { Platform, StyleSheet, Text, TouchableOpacity } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import CourseTableErrorBoundary from '@/components/CourseTableErrorBoundary';
+import Toast from '@/components/toast';
 import View from '@/components/view';
 import { TABBAR_BASE_HEIGHT } from '@/constants/TABBAR';
 import { useCourseLiveActivity } from '@/hooks/useCourseLiveActivity';
@@ -21,11 +24,11 @@ import {
 import useCourse from '@/store/course';
 import useTimeStore from '@/store/time';
 import useVisualScheme from '@/store/visualScheme';
+import { CourseDataError, parseCourseTableResponse } from '@/utils/courseData';
 import {
   courseLiveActivity,
   LIVE_ACTIVITY_ENABLED,
 } from '@/utils/courseLiveActivity';
-import { serializeCoursesForAppleWidget } from '@/utils/courseRuntime';
 import {
   buildSemesterOptions,
   parseSemester,
@@ -39,28 +42,44 @@ import {
 } from '@/utils/semesterWeeks';
 
 import CourseTable from './components/courseTable';
-import type {
-  courseType,
-  SemesterWeekParams,
-} from './components/courseTable/type';
+import type { SemesterWeekParams } from './components/courseTable/type';
 import WeekSelector from './components/WeekSelector';
+
+type SemesterApiResponse = {
+  code?: unknown;
+  data?: unknown;
+  msg?: unknown;
+};
+
+const getTimetableErrorMessage = (error: unknown) => {
+  if (error instanceof CourseDataError) return error.message;
+  if (error instanceof Error && /timeout/i.test(error.message)) {
+    return '教务系统响应超时，请稍后重试';
+  }
+  return '网络连接异常，请检查网络后重试';
+};
 
 const CourseTablePage: FC = () => {
   const currentStyle = useVisualScheme(state => state.currentStyle);
+  const courseHydrated = useCourse(state => state.hydrated);
+  const timeHydrated = useTimeStore(state => state.hydrated);
   const extensionStorage = useMemo(() => {
     return new ExtensionStorage('group.release-20240916');
   }, []);
 
-  const { courses, updateCourses, setLastUpdate } = useCourse();
+  const {
+    courses,
+    lastUpdate,
+    clearSemester,
+    setActiveSemester,
+    replaceSemesterCourses,
+  } = useCourse();
   const {
     semester,
-    setSemester,
     year,
-    setYear,
     selectedWeek,
     setSelectedWeek,
-    setHolidayTime,
-    setSchoolTime,
+    setSemesterContext,
     showWeekPicker,
     setShowWeekPicker,
   } = useTimeStore();
@@ -74,38 +93,63 @@ const CourseTablePage: FC = () => {
     'year' | 'semester'
   > | null>(null);
   const [actualCurrentWeek, setActualCurrentWeek] = useState(1);
+  const [timetableStatus, setTimetableStatus] = useState<
+    'idle' | 'loading' | 'refreshing' | 'ready' | 'stale' | 'error'
+  >('idle');
+  const requestSequence = useRef(0);
+  const initialized = useRef(false);
 
-  const totalWeeks = useTimeStore(state => state.getSemesterWeekCount());
-
-  const syncCoursesToWidget = useCallback(
-    (nextCourses: courseType[]) => {
-      extensionStorage.set(
-        'courseTable',
-        serializeCoursesForAppleWidget(nextCourses)
-      );
-      ExtensionStorage.reloadWidget();
-    },
-    [extensionStorage]
+  const calendarWeekCount = useTimeStore(state => state.getSemesterWeekCount());
+  const maxCourseWeek = useMemo(
+    () =>
+      courses.reduce(
+        (maximum, course) =>
+          Math.max(
+            maximum,
+            ...(Array.isArray(course.weeks) ? course.weeks : [])
+          ),
+        0
+      ),
+    [courses]
   );
+  const totalWeeks = Math.max(calendarWeekCount, maxCourseWeek, 1);
 
-  const applySemesterTime = useCallback(
-    (option: SemesterOptionBase) => {
-      setSchoolTime(option.startTimestamp);
-      setHolidayTime(option.endTimestamp);
+  const applySemesterContext = useCallback(
+    (option: SemesterOptionBase, week: number) => {
+      const totalWeeks = calculateSemesterWeekCount(
+        option.startTimestamp,
+        option.endTimestamp
+      );
+      setSemesterContext({
+        year: option.year,
+        semester: option.semester,
+        selectedWeek: clampWeekToSemester(week, totalWeeks),
+        schoolTime: option.startTimestamp,
+        holidayTime: option.endTimestamp,
+      });
+      setActiveSemester(option.year, option.semester);
       extensionStorage.set('schoolTime', option.startTimestamp);
       extensionStorage.set('holidayTime', option.endTimestamp);
       ExtensionStorage.reloadWidget();
     },
-    [extensionStorage, setHolidayTime, setSchoolTime]
+    [extensionStorage, setActiveSemester, setSemesterContext]
   );
 
   const fetchSemesterInfo = useCallback(async () => {
-    const [currentRes, listRes] = await Promise.all([
+    const [currentResRaw, listResRaw] = await Promise.all([
       queryCurrentSemester(),
       querySemesterList(),
     ]);
-    const current = parseSemester(currentRes.data);
-    const options = buildSemesterOptions(listRes.data ?? []);
+    const currentRes = currentResRaw as unknown as SemesterApiResponse;
+    const listRes = listResRaw as unknown as SemesterApiResponse;
+    const current = parseSemester(
+      currentRes.data as Parameters<typeof parseSemester>[0]
+    );
+    const options = buildSemesterOptions(
+      (Array.isArray(listRes.data) ? listRes.data : []) as Parameters<
+        typeof buildSemesterOptions
+      >[0]
+    );
 
     if (
       currentRes.code !== 0 ||
@@ -118,19 +162,15 @@ const CourseTablePage: FC = () => {
 
     setSemesterOptions(options);
     setCurrentSemester({ year: current.year, semester: current.semester });
-    setYear(current.year);
-    setSemester(current.semester);
-    applySemesterTime(current);
-
     const currentWeek = clampWeekToSemester(
       calculateWeekFromStart(current.startTimestamp),
       calculateSemesterWeekCount(current.startTimestamp, current.endTimestamp)
     );
+    applySemesterContext(current, currentWeek);
     setActualCurrentWeek(currentWeek);
-    setSelectedWeek(currentWeek);
 
     return current;
-  }, [applySemesterTime, setSelectedWeek, setSemester, setYear]);
+  }, [applySemesterContext]);
 
   const fetchTimetable = useCallback(
     async (
@@ -138,28 +178,56 @@ const CourseTablePage: FC = () => {
       targetSemester: string,
       forceRefresh = false
     ) => {
+      if (!targetYear || !targetSemester) {
+        throw new CourseDataError('missing_scope', '学期信息尚未加载');
+      }
+
+      const requestId = ++requestSequence.current;
       const res = await queryCourseTable({
         semester: targetSemester,
         year: targetYear,
         refresh: forceRefresh,
       });
 
-      if (res?.code === 0 && res.data?.classes && res.data.last_refresh_time) {
-        const nextCourses = res.data.classes as courseType[];
-        updateCourses(nextCourses);
-        syncCoursesToWidget(nextCourses);
-        setLastUpdate(res.data.last_refresh_time);
+      const parsed = parseCourseTableResponse(res, {
+        year: targetYear,
+        semester: targetSemester,
+      });
+
+      if (requestId !== requestSequence.current) {
+        return;
       }
+
+      if (parsed.droppedCount > 0) {
+        log.warn(`课表数据已忽略 ${parsed.droppedCount} 条异常课程`);
+        Toast.show({
+          text: `发现 ${parsed.droppedCount} 条异常课程，已安全忽略`,
+          icon: 'fail',
+        });
+      }
+
+      replaceSemesterCourses(
+        targetYear,
+        targetSemester,
+        parsed.courses,
+        parsed.lastRefreshTime
+      );
     },
-    [setLastUpdate, syncCoursesToWidget, updateCourses]
+    [replaceSemesterCourses]
   );
 
   const onTimetableRefresh = useCallback(
     async (forceRefresh: boolean = false) => {
+      setTimetableStatus(forceRefresh ? 'refreshing' : 'loading');
       try {
         await fetchTimetable(year, semester, forceRefresh);
+        setTimetableStatus('ready');
       } catch (error) {
+        setTimetableStatus(
+          useCourse.getState().courses.length > 0 ? 'stale' : 'error'
+        );
         log.error('Failed to refresh timetable:', error);
+        throw error;
       }
     },
     [fetchTimetable, semester, year]
@@ -172,20 +240,35 @@ const CourseTablePage: FC = () => {
       week,
     }: SemesterWeekParams) => {
       const semesterChanged = newYear !== year || newSemester !== semester;
-      setYear(newYear);
-      setSemester(newSemester);
       const nextSemester = semesterOptions.find(
         option => option.year === newYear && option.semester === newSemester
       );
-      if (nextSemester) applySemesterTime(nextSemester);
-      if (week !== undefined) setSelectedWeek(week);
+      if (!nextSemester) {
+        Toast.show({ text: '学期信息无效，请重新选择', icon: 'fail' });
+        return;
+      }
+
+      if (semesterChanged) {
+        applySemesterContext(nextSemester, week ?? selectedWeek);
+      } else if (week !== undefined) {
+        setSelectedWeek(week);
+      }
 
       if (semesterChanged) {
         setIsLoadingTimetable(true);
+        setTimetableStatus('loading');
         try {
           await fetchTimetable(newYear, newSemester);
+          setTimetableStatus('ready');
         } catch (error) {
           log.error('切换学期失败:', error);
+          setTimetableStatus(
+            useCourse.getState().courses.length > 0 ? 'stale' : 'error'
+          );
+          Toast.show({
+            text: getTimetableErrorMessage(error),
+            icon: 'fail',
+          });
         } finally {
           setIsLoadingTimetable(false);
         }
@@ -195,10 +278,9 @@ const CourseTablePage: FC = () => {
     [
       year,
       semester,
-      setYear,
-      setSemester,
       semesterOptions,
-      applySemesterTime,
+      applySemesterContext,
+      selectedWeek,
       setSelectedWeek,
       fetchTimetable,
       setShowWeekPicker,
@@ -206,21 +288,55 @@ const CourseTablePage: FC = () => {
   );
 
   useEffect(() => {
+    if (!courseHydrated || !timeHydrated || initialized.current) return;
+    initialized.current = true;
+
     const initialize = async () => {
+      let targetYear = useTimeStore.getState().year;
+      let targetSemester = useTimeStore.getState().semester;
+
       try {
         const current = await fetchSemesterInfo();
-        await fetchTimetable(current.year, current.semester);
+        targetYear = current.year;
+        targetSemester = current.semester;
+      } catch (semesterError) {
+        log.error('Failed to initialize semester metadata:', semesterError);
+      }
+
+      if (!targetYear || !targetSemester) {
+        setTimetableStatus('error');
+        Toast.show({
+          text: '学期信息加载失败，请稍后重试',
+          icon: 'fail',
+        });
+        return;
+      }
+
+      setActiveSemester(targetYear, targetSemester);
+      setTimetableStatus('loading');
+      try {
+        await fetchTimetable(targetYear, targetSemester);
+        setTimetableStatus('ready');
       } catch (error) {
-        log.error('Failed to initialize semester data:', error);
+        log.error('Failed to initialize timetable:', error);
+        setTimetableStatus(
+          useCourse.getState().courses.length > 0 ? 'stale' : 'error'
+        );
+        Toast.show({
+          text: getTimetableErrorMessage(error),
+          icon: 'fail',
+        });
       }
     };
 
     void initialize();
-  }, [fetchSemesterInfo, fetchTimetable]);
-
-  useEffect(() => {
-    setSelectedWeek(selectedWeek);
-  }, [selectedWeek, setSelectedWeek, totalWeeks]);
+  }, [
+    courseHydrated,
+    fetchSemesterInfo,
+    fetchTimetable,
+    setActiveSemester,
+    timeHydrated,
+  ]);
 
   // 启用 Live Activity 自动提醒
   useCourseLiveActivity(courses);
@@ -270,11 +386,44 @@ const CourseTablePage: FC = () => {
         currentStyle?.background_style,
       ]}
     >
-      <CourseTable
-        data={courses}
-        onTimetableRefresh={onTimetableRefresh}
-        currentWeek={selectedWeek}
-      />
+      <CourseTableErrorBoundary
+        key={`${year}-${semester}-${lastUpdate}`}
+        onReset={() => {
+          clearSemester(year, semester);
+          void onTimetableRefresh(true).catch(() => undefined);
+        }}
+      >
+        <CourseTable
+          data={courses}
+          onTimetableRefresh={onTimetableRefresh}
+          currentWeek={selectedWeek}
+        />
+      </CourseTableErrorBoundary>
+      {timetableStatus === 'loading' && courses.length === 0 && (
+        <View style={styles.statusBanner}>
+          <Text style={styles.statusText}>正在获取课表…</Text>
+        </View>
+      )}
+      {timetableStatus === 'stale' && (
+        <View style={styles.statusBanner}>
+          <Text style={styles.statusText}>刷新失败，当前展示本地缓存</Text>
+        </View>
+      )}
+      {timetableStatus === 'error' && courses.length === 0 && (
+        <TouchableOpacity
+          style={styles.statusBanner}
+          onPress={() => {
+            void onTimetableRefresh(true).catch(() => undefined);
+          }}
+        >
+          <Text style={styles.statusText}>课表加载失败，点击重试</Text>
+        </TouchableOpacity>
+      )}
+      {timetableStatus === 'ready' && courses.length === 0 && (
+        <View style={styles.statusBanner}>
+          <Text style={styles.statusText}>本学期暂无课程</Text>
+        </View>
+      )}
       {showWeekPicker && (
         <WeekSelector
           currentWeek={selectedWeek}
@@ -304,6 +453,21 @@ const CourseTablePage: FC = () => {
 };
 
 const styles = StyleSheet.create({
+  statusBanner: {
+    position: 'absolute',
+    top: 12,
+    left: 20,
+    right: 20,
+    zIndex: 200,
+    borderRadius: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    backgroundColor: 'rgba(40, 40, 40, 0.82)',
+  },
+  statusText: {
+    color: '#FFFFFF',
+    textAlign: 'center',
+  },
   testButton: {
     position: 'absolute',
     top: 20,

--- a/src/request/api/course/queryCourseTable.ts
+++ b/src/request/api/course/queryCourseTable.ts
@@ -8,15 +8,14 @@ interface QueryParams {
 
 // 查询课表
 const queryCourseTable = async (queryParams: QueryParams) => {
-  try {
-    return await request.get('/class/get', {
-      query: queryParams,
-      header: { Authorization: '' },
-    });
-  } catch (error) {
-    console.error('查询课表接口出错:', error);
-    // throw error;
+  if (!queryParams.year || !/^[123]$/.test(queryParams.semester)) {
+    throw new Error('学期信息尚未加载');
   }
+
+  return request.get('/class/get', {
+    query: queryParams,
+    header: { Authorization: '' },
+  });
 };
 
 export default queryCourseTable;

--- a/src/store/course.ts
+++ b/src/store/course.ts
@@ -116,20 +116,34 @@ const normalizePersistedState = (value: unknown): PersistedCourseState => {
       );
     }
   } else if (Array.isArray(value.courses)) {
-    const legacyCourses = sanitizeCourseList(value.courses).courses;
-    for (const course of legacyCourses) {
-      const key = getCourseScopeKey(course.year, course.semester);
-      const bucket =
-        buckets[key] ??
-        createBucket(
-          course.year,
-          course.semester,
-          [],
-          value.lastUpdate,
-          Date.now()
-        );
-      bucket.courses.push(course);
-      buckets[key] = bucket;
+    const legacyCoursesByScope: Record<string, unknown[]> = {};
+
+    for (const rawCourse of value.courses) {
+      if (!isRecord(rawCourse)) continue;
+
+      const year =
+        typeof rawCourse.year === 'string' ? rawCourse.year.trim() : '';
+      const semester =
+        typeof rawCourse.semester === 'string' ? rawCourse.semester.trim() : '';
+      if (!isValidCourseScope(year, semester)) continue;
+
+      const key = getCourseScopeKey(year, semester);
+      const scopedCourses = legacyCoursesByScope[key] ?? [];
+      scopedCourses.push(rawCourse);
+      legacyCoursesByScope[key] = scopedCourses;
+    }
+
+    for (const [key, scopedCourses] of Object.entries(legacyCoursesByScope)) {
+      const scope = parseScopeKey(key);
+      if (!scope) continue;
+
+      buckets[key] = createBucket(
+        scope.year,
+        scope.semester,
+        scopedCourses,
+        value.lastUpdate,
+        Date.now()
+      );
     }
   }
 

--- a/src/store/course.ts
+++ b/src/store/course.ts
@@ -2,74 +2,331 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
-import { courseType } from '@/modules/courseTable/components/courseTable/type';
+import type { courseType } from '@/modules/courseTable/components/courseTable/type';
+import {
+  getCourseScopeKey,
+  isValidCourseScope,
+  sanitizeCourse,
+  sanitizeCourseList,
+} from '@/utils/courseData';
 import { updateCourseWidgetData } from '@/utils/updateWidget';
 
-interface CourseState {
-  hydrated: boolean;
-  setHydrated: (hydrated: boolean) => void;
+const COURSE_STORE_VERSION = 2;
+
+type CourseBuckets = Record<string, CourseBucket>;
+
+export interface CourseBucket {
   courses: courseType[];
-  courseCategories: string[];
-  updateCourses: (courses: courseType[]) => void;
-  updatecourseCategories: (coursesCategory: string[]) => void;
-  addCourse: (course: courseType) => void;
-  deleteCourse: (id: string) => void;
-  updateCourseNote: (id: string, note: string) => void;
-  lastUpdate: number;
-  setLastUpdate: (time: number) => void;
+  fetchedAt: number;
+  lastRefreshTime: number;
+  semester: string;
+  year: string;
 }
+
+interface PersistedCourseState {
+  activeKey: string | null;
+  buckets: CourseBuckets;
+  courseCategories: string[];
+}
+
+interface CourseState extends PersistedCourseState {
+  hydrated: boolean;
+  rehydrateError: string | null;
+  courses: courseType[];
+  lastUpdate: number;
+  setHydrated: (_hydrated: boolean, _error?: string | null) => void;
+  setActiveSemester: (_year: string, _semester: string) => void;
+  replaceSemesterCourses: (
+    _year: string,
+    _semester: string,
+    _courses: unknown,
+    _lastRefreshTime: number
+  ) => void;
+  clearSemester: (_year: string, _semester: string) => void;
+  updateCourses: (_courses: courseType[]) => void;
+  updatecourseCategories: (_coursesCategory: string[]) => void;
+  addCourse: (_course: courseType) => void;
+  deleteCourse: (_id: string) => void;
+  updateCourseNote: (_id: string, _note: string) => void;
+  setLastUpdate: (_time: number) => void;
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const toTimestamp = (value: unknown) =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : 0;
+
+const parseScopeKey = (key: unknown) => {
+  if (typeof key !== 'string') return null;
+  const match = /^(\d{4})-([123])$/.exec(key);
+  return match ? { year: match[1], semester: match[2] } : null;
+};
+
+const createBucket = (
+  year: string,
+  semester: string,
+  courses: unknown,
+  lastRefreshTime: unknown,
+  fetchedAt: unknown = Date.now()
+): CourseBucket => ({
+  year,
+  semester,
+  courses: sanitizeCourseList(courses, { year, semester }).courses,
+  lastRefreshTime: toTimestamp(lastRefreshTime),
+  fetchedAt: toTimestamp(fetchedAt) || Date.now(),
+});
+
+const normalizePersistedState = (value: unknown): PersistedCourseState => {
+  const fallback: PersistedCourseState = {
+    activeKey: null,
+    buckets: {},
+    courseCategories: [],
+  };
+  if (!isRecord(value)) return fallback;
+
+  const buckets: CourseBuckets = {};
+  if (isRecord(value.buckets)) {
+    for (const [rawKey, rawBucket] of Object.entries(value.buckets)) {
+      if (!isRecord(rawBucket)) continue;
+      const keyScope = parseScopeKey(rawKey);
+      const year =
+        typeof rawBucket.year === 'string' ? rawBucket.year : keyScope?.year;
+      const semester =
+        typeof rawBucket.semester === 'string'
+          ? rawBucket.semester
+          : keyScope?.semester;
+      if (
+        typeof year !== 'string' ||
+        typeof semester !== 'string' ||
+        !isValidCourseScope(year, semester)
+      ) {
+        continue;
+      }
+
+      const key = getCourseScopeKey(year, semester);
+      buckets[key] = createBucket(
+        year,
+        semester,
+        rawBucket.courses,
+        rawBucket.lastRefreshTime,
+        rawBucket.fetchedAt
+      );
+    }
+  } else if (Array.isArray(value.courses)) {
+    const legacyCourses = sanitizeCourseList(value.courses).courses;
+    for (const course of legacyCourses) {
+      const key = getCourseScopeKey(course.year, course.semester);
+      const bucket =
+        buckets[key] ??
+        createBucket(
+          course.year,
+          course.semester,
+          [],
+          value.lastUpdate,
+          Date.now()
+        );
+      bucket.courses.push(course);
+      buckets[key] = bucket;
+    }
+  }
+
+  const requestedActiveKey =
+    typeof value.activeKey === 'string' ? value.activeKey : null;
+  const activeKey =
+    requestedActiveKey && parseScopeKey(requestedActiveKey)
+      ? requestedActiveKey
+      : (Object.keys(buckets)[0] ?? null);
+
+  return {
+    activeKey,
+    buckets,
+    courseCategories: Array.isArray(value.courseCategories)
+      ? value.courseCategories.filter(
+          (category): category is string => typeof category === 'string'
+        )
+      : [],
+  };
+};
+
+const getActiveSnapshot = (
+  activeKey: string | null,
+  buckets: CourseBuckets
+) => {
+  const bucket = activeKey ? buckets[activeKey] : undefined;
+  return {
+    courses: bucket?.courses ?? [],
+    lastUpdate: bucket?.lastRefreshTime ?? 0,
+  };
+};
+
+const syncWidget = (courses: courseType[]) => {
+  void updateCourseWidgetData(courses).catch(() => undefined);
+};
 
 const useCourse = create<CourseState>()(
   persist(
-    set => {
-      return {
-        hydrated: false,
-        setHydrated: (hydrated: boolean) => set({ hydrated }),
-        courses: [],
-        courseCategories: [],
-        updateCourses: (courses: courseType[]) => {
-          set(state => ({
-            courses,
-            courseCategories: state.courseCategories,
-          }));
-          void updateCourseWidgetData(courses);
-        },
-        updatecourseCategories: (courseCategories: string[]) => {
-          set(state => ({
-            courses: state.courses,
-            courseCategories,
-          }));
-        },
-        addCourse: (course: courseType) => {
-          const courses = [...useCourse.getState().courses, course];
-          set({ courses });
-          void updateCourseWidgetData(courses);
-        },
-        deleteCourse: (id: string) => {
-          const courses = useCourse.getState().courses.filter(c => c.id !== id);
-          set({ courses });
-          void updateCourseWidgetData(courses);
-        },
-        updateCourseNote: (id: string, note: string) => {
-          const courses = useCourse
-            .getState()
-            .courses.map(course =>
-              course.id === id ? { ...course, note } : course
-            );
-          set({ courses });
-          void updateCourseWidgetData(courses);
-        },
-        lastUpdate: 0,
-        setLastUpdate: (time: number) => set({ lastUpdate: time }),
-      };
-    },
+    (set, get) => ({
+      hydrated: false,
+      rehydrateError: null,
+      activeKey: null,
+      buckets: {},
+      courses: [],
+      courseCategories: [],
+      lastUpdate: 0,
+      setHydrated: (hydrated, error = null) =>
+        set({ hydrated, rehydrateError: error }),
+      setActiveSemester: (year, semester) => {
+        if (!isValidCourseScope(year, semester)) return;
+        const activeKey = getCourseScopeKey(year, semester);
+        const snapshot = getActiveSnapshot(activeKey, get().buckets);
+        set({ activeKey, ...snapshot });
+        syncWidget(snapshot.courses);
+      },
+      replaceSemesterCourses: (year, semester, courses, lastRefreshTime) => {
+        if (!isValidCourseScope(year, semester)) return;
+        const key = getCourseScopeKey(year, semester);
+        const bucket = createBucket(year, semester, courses, lastRefreshTime);
+        const buckets = { ...get().buckets, [key]: bucket };
+        const isActive = get().activeKey === key;
+        set({
+          buckets,
+          ...(isActive
+            ? { courses: bucket.courses, lastUpdate: bucket.lastRefreshTime }
+            : {}),
+        });
+        if (isActive) syncWidget(bucket.courses);
+      },
+      clearSemester: (year, semester) => {
+        if (!isValidCourseScope(year, semester)) return;
+        const key = getCourseScopeKey(year, semester);
+        const buckets = { ...get().buckets };
+        delete buckets[key];
+        const isActive = get().activeKey === key;
+        set({
+          buckets,
+          ...(isActive ? { courses: [], lastUpdate: 0 } : {}),
+        });
+        if (isActive) syncWidget([]);
+      },
+      updateCourses: courses => {
+        const sanitized = sanitizeCourseList(courses).courses;
+        const scope = sanitized[0]
+          ? { year: sanitized[0].year, semester: sanitized[0].semester }
+          : parseScopeKey(get().activeKey);
+        if (!scope) return;
+        get().replaceSemesterCourses(
+          scope.year,
+          scope.semester,
+          sanitized,
+          get().lastUpdate
+        );
+      },
+      updatecourseCategories: courseCategories =>
+        set({
+          courseCategories: courseCategories.filter(
+            category => typeof category === 'string'
+          ),
+        }),
+      addCourse: rawCourse => {
+        const course = sanitizeCourse(rawCourse);
+        if (!course) return;
+        const key = getCourseScopeKey(course.year, course.semester);
+        const existing = get().buckets[key];
+        const nextCourses = sanitizeCourseList([
+          ...(existing?.courses ?? []),
+          course,
+        ]).courses;
+        const bucket = createBucket(
+          course.year,
+          course.semester,
+          nextCourses,
+          existing?.lastRefreshTime ?? 0,
+          existing?.fetchedAt ?? Date.now()
+        );
+        const buckets = { ...get().buckets, [key]: bucket };
+        const isActive = get().activeKey === key;
+        set({
+          buckets,
+          ...(isActive ? { courses: bucket.courses } : {}),
+        });
+        if (isActive) syncWidget(bucket.courses);
+      },
+      deleteCourse: id => {
+        const activeKey = get().activeKey;
+        if (!activeKey) return;
+        const bucket = get().buckets[activeKey];
+        if (!bucket) return;
+        const courses = bucket.courses.filter(course => course.id !== id);
+        const nextBucket = { ...bucket, courses };
+        set({
+          buckets: { ...get().buckets, [activeKey]: nextBucket },
+          courses,
+        });
+        syncWidget(courses);
+      },
+      updateCourseNote: (id, note) => {
+        const activeKey = get().activeKey;
+        if (!activeKey) return;
+        const bucket = get().buckets[activeKey];
+        if (!bucket) return;
+        const courses = bucket.courses.map(course =>
+          course.id === id ? { ...course, note } : course
+        );
+        set({
+          buckets: {
+            ...get().buckets,
+            [activeKey]: { ...bucket, courses },
+          },
+          courses,
+        });
+        syncWidget(courses);
+      },
+      setLastUpdate: lastUpdate => {
+        const activeKey = get().activeKey;
+        if (!activeKey) return;
+        const bucket = get().buckets[activeKey];
+        if (!bucket) {
+          set({ lastUpdate: toTimestamp(lastUpdate) });
+          return;
+        }
+        const nextBucket = {
+          ...bucket,
+          lastRefreshTime: toTimestamp(lastUpdate),
+        };
+        set({
+          buckets: { ...get().buckets, [activeKey]: nextBucket },
+          lastUpdate: nextBucket.lastRefreshTime,
+        });
+      },
+    }),
     {
       name: 'courses',
+      version: COURSE_STORE_VERSION,
       storage: createJSONStorage(() => AsyncStorage),
-      onRehydrateStorage: state => {
-        return () => {
-          state?.setHydrated(true);
+      partialize: state => ({
+        activeKey: state.activeKey,
+        buckets: state.buckets,
+        courseCategories: state.courseCategories,
+      }),
+      migrate: persistedState => normalizePersistedState(persistedState),
+      merge: (persistedState, currentState) => {
+        const normalized = normalizePersistedState(persistedState);
+        return {
+          ...currentState,
+          ...normalized,
+          ...getActiveSnapshot(normalized.activeKey, normalized.buckets),
         };
+      },
+      onRehydrateStorage: () => (state, error) => {
+        const errorMessage =
+          error instanceof Error ? error.message : error ? String(error) : null;
+        if (state) state.setHydrated(true, errorMessage);
+        else
+          useCourse.setState({ hydrated: true, rehydrateError: errorMessage });
+        if (!error && state) syncWidget(state.courses);
       },
     }
   )

--- a/src/store/time.ts
+++ b/src/store/time.ts
@@ -8,16 +8,26 @@ import {
   clampWeekToSemester,
 } from '@/utils/semesterWeeks';
 
-interface TimeState {
+const TIME_STORE_VERSION = 2;
+const MAX_REASONABLE_WEEK = 60;
+
+interface PersistedTimeState {
   semester: string;
-  setSemester: (_semester: string) => void;
   year: string;
-  setYear: (_year: string) => void;
   selectedWeek: number;
-  setSelectedWeek: (_week: number) => void;
   holidayTime: number;
-  setHolidayTime: (_time: number) => void;
   schoolTime: number;
+}
+
+interface TimeState extends PersistedTimeState {
+  hydrated: boolean;
+  rehydrateError: string | null;
+  setHydrated: (_hydrated: boolean, _error?: string | null) => void;
+  setSemester: (_semester: string) => void;
+  setYear: (_year: string) => void;
+  setSemesterContext: (_context: PersistedTimeState) => void;
+  setSelectedWeek: (_week: number) => void;
+  setHolidayTime: (_time: number) => void;
   setSchoolTime: (_time: number) => void;
   showWeekPicker: boolean;
   setShowWeekPicker: (_opened: boolean) => void;
@@ -25,36 +35,99 @@ interface TimeState {
   getSemesterWeekCount: () => number;
 }
 
+type UnknownRecord = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const normalizeScopeValue = (value: unknown, pattern: RegExp) =>
+  typeof value === 'string' && pattern.test(value) ? value : '';
+
+const normalizeTimestamp = (value: unknown) =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : 0;
+
+const normalizeWeek = (value: unknown) => {
+  const week = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(week)
+    ? clampWeekToSemester(Math.round(week), MAX_REASONABLE_WEEK)
+    : 1;
+};
+
+const normalizePersistedTime = (value: unknown): PersistedTimeState => {
+  if (!isRecord(value)) {
+    return {
+      semester: '',
+      year: '',
+      selectedWeek: 1,
+      holidayTime: 0,
+      schoolTime: 0,
+    };
+  }
+
+  return {
+    semester: normalizeScopeValue(value.semester, /^[123]$/),
+    year: normalizeScopeValue(value.year, /^\d{4}$/),
+    selectedWeek: normalizeWeek(value.selectedWeek),
+    holidayTime: normalizeTimestamp(value.holidayTime),
+    schoolTime: normalizeTimestamp(value.schoolTime),
+  };
+};
+
 const useTimeStore = create<TimeState>()(
   persist(
-    (set, get) => {
-      return {
-        semester: '',
-        setSemester: (semester: string) => set({ semester }),
-        year: '',
-        setYear: (year: string) => set({ year }),
-        selectedWeek: 1,
-        setSelectedWeek: (week: number) => {
-          const totalWeeks = get().getSemesterWeekCount();
-          set({ selectedWeek: clampWeekToSemester(week, totalWeeks) });
-        },
-        holidayTime: 0,
-        setHolidayTime: (_time: number) => set({ holidayTime: _time }),
-        schoolTime: 0,
-        setSchoolTime: (_time: number) => set({ schoolTime: _time }),
-        showWeekPicker: false,
-        setShowWeekPicker: (showWeekPicker: boolean) =>
-          set({ showWeekPicker: showWeekPicker }),
-        getCurrentWeek: () => calculateWeekFromStart(get().schoolTime),
-        getSemesterWeekCount: () => {
-          const { schoolTime, holidayTime } = get();
-          return calculateSemesterWeekCount(schoolTime, holidayTime);
-        },
-      };
-    },
+    (set, get) => ({
+      hydrated: false,
+      rehydrateError: null,
+      setHydrated: (hydrated, error = null) =>
+        set({ hydrated, rehydrateError: error }),
+      semester: '',
+      setSemester: semester =>
+        set({ semester: normalizeScopeValue(semester, /^[123]$/) }),
+      year: '',
+      setYear: year => set({ year: normalizeScopeValue(year, /^\d{4}$/) }),
+      setSemesterContext: context => set(normalizePersistedTime(context)),
+      selectedWeek: 1,
+      setSelectedWeek: week => set({ selectedWeek: normalizeWeek(week) }),
+      holidayTime: 0,
+      setHolidayTime: holidayTime =>
+        set({ holidayTime: normalizeTimestamp(holidayTime) }),
+      schoolTime: 0,
+      setSchoolTime: schoolTime =>
+        set({ schoolTime: normalizeTimestamp(schoolTime) }),
+      showWeekPicker: false,
+      setShowWeekPicker: showWeekPicker => set({ showWeekPicker }),
+      getCurrentWeek: () => calculateWeekFromStart(get().schoolTime),
+      getSemesterWeekCount: () => {
+        const { schoolTime, holidayTime } = get();
+        return calculateSemesterWeekCount(schoolTime, holidayTime);
+      },
+    }),
     {
       name: 'time',
+      version: TIME_STORE_VERSION,
       storage: createJSONStorage(() => AsyncStorage),
+      partialize: state => ({
+        semester: state.semester,
+        year: state.year,
+        selectedWeek: state.selectedWeek,
+        holidayTime: state.holidayTime,
+        schoolTime: state.schoolTime,
+      }),
+      migrate: persistedState => normalizePersistedTime(persistedState),
+      merge: (persistedState, currentState) => ({
+        ...currentState,
+        ...normalizePersistedTime(persistedState),
+      }),
+      onRehydrateStorage: () => (state, error) => {
+        const errorMessage =
+          error instanceof Error ? error.message : error ? String(error) : null;
+        if (state) state.setHydrated(true, errorMessage);
+        else
+          useTimeStore.setState({
+            hydrated: true,
+            rehydrateError: errorMessage,
+          });
+      },
     }
   )
 );

--- a/src/utils/courseData.ts
+++ b/src/utils/courseData.ts
@@ -1,0 +1,227 @@
+import type { courseType } from '@/modules/courseTable/components/courseTable/type';
+import { parseClassWhen } from '@/utils/courseRuntime';
+
+const MAX_REASONABLE_WEEK = 60;
+
+type UnknownRecord = Record<string, unknown>;
+
+export interface CourseScope {
+  semester: string;
+  year: string;
+}
+
+export interface SanitizedCourseList {
+  courses: courseType[];
+  droppedCount: number;
+}
+
+export interface ParsedCourseTableResponse extends SanitizedCourseList {
+  lastRefreshTime: number;
+}
+
+export class CourseDataError extends Error {
+  readonly kind: 'invalid_payload' | 'missing_scope' | 'server';
+
+  constructor(
+    kind: 'invalid_payload' | 'missing_scope' | 'server',
+    message: string
+  ) {
+    super(message);
+    this.name = 'CourseDataError';
+    this.kind = kind;
+  }
+}
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const toTrimmedString = (value: unknown, fallback = '') => {
+  if (typeof value !== 'string') return fallback;
+  return value.trim() || fallback;
+};
+
+const toInteger = (value: unknown): number | null => {
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim() !== ''
+        ? Number(value)
+        : Number.NaN;
+  return Number.isInteger(parsed) ? parsed : null;
+};
+
+const toFiniteNumber = (value: unknown, fallback = 0) => {
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim() !== ''
+        ? Number(value)
+        : Number.NaN;
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+};
+
+const toBoolean = (value: unknown) => {
+  if (value === true || value === 1 || value === 'true') return true;
+  if (value === false || value === 0 || value === 'false') return false;
+  return false;
+};
+
+const readLegacyWeeks = (value: unknown): unknown[] => {
+  if (Array.isArray(value)) return value;
+  if (typeof value !== 'string') return [];
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+export const sanitizeWeeks = (value: unknown): number[] => {
+  const weeks = readLegacyWeeks(value)
+    .map(toInteger)
+    .filter(
+      (week): week is number =>
+        week !== null && week >= 1 && week <= MAX_REASONABLE_WEEK
+    );
+
+  return [...new Set(weeks)].sort((left, right) => left - right);
+};
+
+export const buildWeekDuration = (weeks: number[]) => {
+  if (weeks.length === 0) return '';
+  if (weeks.length === 1) return `${weeks[0]}周`;
+
+  const isContinuous = weeks.every(
+    (week, index) => index === 0 || week === weeks[index - 1] + 1
+  );
+  return isContinuous
+    ? `${weeks[0]}-${weeks[weeks.length - 1]}周`
+    : `${weeks.join(',')}周`;
+};
+
+export const isValidCourseScope = (year: unknown, semester: unknown): boolean =>
+  typeof year === 'string' &&
+  /^\d{4}$/.test(year) &&
+  typeof semester === 'string' &&
+  /^[123]$/.test(semester);
+
+export const getCourseScopeKey = (year: string, semester: string) =>
+  `${year}-${semester}` as const;
+
+export const sanitizeCourse = (
+  value: unknown,
+  expectedScope?: CourseScope
+): courseType | null => {
+  if (!isRecord(value)) return null;
+
+  const id = toTrimmedString(value.id);
+  const classname = toTrimmedString(value.classname);
+  const year = toTrimmedString(value.year);
+  const semester = toTrimmedString(value.semester);
+  const day = toInteger(value.day);
+  const parsedRange = parseClassWhen(value.class_when);
+  const weeks = sanitizeWeeks(value.weeks);
+
+  if (
+    !id ||
+    !classname ||
+    !isValidCourseScope(year, semester) ||
+    day === null ||
+    day < 1 ||
+    day > 7 ||
+    !parsedRange ||
+    weeks.length === 0
+  ) {
+    return null;
+  }
+
+  if (
+    expectedScope &&
+    (year !== expectedScope.year || semester !== expectedScope.semester)
+  ) {
+    return null;
+  }
+
+  const weekDuration = toTrimmedString(value.week_duration);
+
+  return {
+    id,
+    classname,
+    teacher: toTrimmedString(value.teacher, '未知教师'),
+    where: toTrimmedString(value.where, '未知地点'),
+    day,
+    class_when: `${parsedRange.startSection}-${parsedRange.endSection}`,
+    weeks,
+    week_duration: weekDuration || buildWeekDuration(weeks),
+    credit: toFiniteNumber(value.credit),
+    semester,
+    year,
+    note: toTrimmedString(value.note),
+    nature: toTrimmedString(
+      value.nature,
+      toBoolean(value.is_official) ? '' : '自定义课程'
+    ),
+    is_official: toBoolean(value.is_official),
+  };
+};
+
+export const sanitizeCourseList = (
+  value: unknown,
+  expectedScope?: CourseScope
+): SanitizedCourseList => {
+  if (!Array.isArray(value)) return { courses: [], droppedCount: 0 };
+
+  const courses: courseType[] = [];
+  const seenIds = new Set<string>();
+  let droppedCount = 0;
+
+  for (const rawCourse of value) {
+    const course = sanitizeCourse(rawCourse, expectedScope);
+    if (!course || seenIds.has(course.id)) {
+      droppedCount += 1;
+      continue;
+    }
+    seenIds.add(course.id);
+    courses.push(course);
+  }
+
+  return { courses, droppedCount };
+};
+
+export const parseCourseTableResponse = (
+  response: unknown,
+  expectedScope: CourseScope
+): ParsedCourseTableResponse => {
+  if (!isValidCourseScope(expectedScope.year, expectedScope.semester)) {
+    throw new CourseDataError('missing_scope', '学期信息无效');
+  }
+  if (!isRecord(response)) {
+    throw new CourseDataError('invalid_payload', '课表接口响应不是对象');
+  }
+  if (response.code !== 0) {
+    throw new CourseDataError(
+      'server',
+      toTrimmedString(response.msg, '课表接口返回失败')
+    );
+  }
+  if (!isRecord(response.data) || !Array.isArray(response.data.classes)) {
+    throw new CourseDataError('invalid_payload', '课表接口缺少课程数组');
+  }
+
+  const lastRefreshTime = toFiniteNumber(
+    response.data.last_refresh_time,
+    Number.NaN
+  );
+  if (!Number.isFinite(lastRefreshTime)) {
+    throw new CourseDataError('invalid_payload', '课表刷新时间无效');
+  }
+
+  const sanitized = sanitizeCourseList(response.data.classes, expectedScope);
+  if (response.data.classes.length > 0 && sanitized.courses.length === 0) {
+    throw new CourseDataError('invalid_payload', '课表课程全部无效');
+  }
+
+  return { ...sanitized, lastRefreshTime };
+};

--- a/src/utils/courseRuntime.ts
+++ b/src/utils/courseRuntime.ts
@@ -42,7 +42,8 @@ const sectionScheduleByNumber = new Map(
 export const parseClassWhen = (classWhen: unknown): ParsedClassWhen | null => {
   if (typeof classWhen !== 'string') return null;
 
-  const match = /^(\d{1,2})(?:-(\d{1,2}))?$/.exec(classWhen.trim());
+  const normalizedClassWhen = classWhen.trim().replace(/\s*-\s*/g, '-');
+  const match = /^(\d{1,2})(?:-(\d{1,2}))?$/.exec(normalizedClassWhen);
   if (!match) return null;
 
   const startSection = Number(match[1]);

--- a/src/utils/courseRuntime.ts
+++ b/src/utils/courseRuntime.ts
@@ -39,12 +39,22 @@ const sectionScheduleByNumber = new Map(
   SECTION_SCHEDULE.map(item => [item.section, item])
 );
 
-export const parseClassWhen = (classWhen: string): ParsedClassWhen | null => {
-  const [rawStartSection, rawEndSection] = classWhen.split('-');
-  const startSection = Number(rawStartSection);
-  const endSection = Number(rawEndSection ?? rawStartSection);
+export const parseClassWhen = (classWhen: unknown): ParsedClassWhen | null => {
+  if (typeof classWhen !== 'string') return null;
 
-  if (!Number.isInteger(startSection) || !Number.isInteger(endSection)) {
+  const match = /^(\d{1,2})(?:-(\d{1,2}))?$/.exec(classWhen.trim());
+  if (!match) return null;
+
+  const startSection = Number(match[1]);
+  const endSection = Number(match[2] ?? match[1]);
+
+  if (
+    !Number.isInteger(startSection) ||
+    !Number.isInteger(endSection) ||
+    startSection < 1 ||
+    endSection > SECTION_SCHEDULE.length ||
+    startSection > endSection
+  ) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

- validate and sanitize timetable API and persisted course data
- migrate course caches to versioned semester-scoped buckets
- propagate request failures and preserve cached data on refresh errors
- harden timetable rendering with bounds checks and a local error boundary
- support real API fields including fractional credits, nature, original week duration text, and weeks beyond 18

## Validation

- targeted oxlint checks pass
- timetable-related TypeScript checks report no errors
- git diff check passes
- commit hooks ran lint and formatting for each commit

## Notes

The repository-wide TypeScript check still reports pre-existing errors in unrelated feedback, icon, style, and API modules. No real timetable response data or test fixture was committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 课表支持加载、刷新、错误重试及缓存回退状态。
  * 新增课表异常提示与重新加载按钮。
  * 课程按学年学期分别保存，切换学期更可靠。
  * 根据实际学期周数动态生成周次选项。

* **问题修复**
  * 自动过滤无效或异常课程，提升课表稳定性。
  * 优化课程时间、周次及更新时间显示。
  * 修复异常数据导致的课表渲染失败。
  * 改善旧版课程与时间数据的恢复兼容性。
  * 增强接口参数校验，避免无效请求。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->