### PR TITLE
fix(quality): 修复异常路径并稳定 Build Test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,19 +35,19 @@ jobs:
             ${{ runner.os }}-pnpm-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
-      - name: Build and Test
-        run: pnpm run build
+      - name: Run Expo Prebuild
+        run: pnpm exec expo prebuild --no-install
         continue-on-error: false
 
       - name: Check if PR should be blocked
         if: github.event_name == 'pull_request'
         run: |
           if [[ "${{ job.status }}" == "failure" ]]; then
-            echo "The 'Build and Test' step failed. The PR will be blocked from merging."
+            echo "The 'Run Expo Prebuild' step failed. The PR will be blocked from merging."
           else
-            echo "The 'Build and Test' step passed. The PR can be merged."
+            echo "The 'Run Expo Prebuild' step passed. The PR can be merged."
           fi
 
       - name: Notify on failure

--- a/src/components/CourseTableErrorBoundary.tsx
+++ b/src/components/CourseTableErrorBoundary.tsx
@@ -2,7 +2,7 @@ import { Button } from '@ant-design/react-native';
 import React from 'react';
 import { Text, View } from 'react-native';
 
-import { log } from '@/utils/logger';
+import { logger } from '@/utils/logger';
 
 interface Props {
   children: React.ReactNode;
@@ -24,7 +24,9 @@ export default class CourseTableErrorBoundary extends React.Component<
   }
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
-    log.error('课表渲染异常:', error, info.componentStack);
+    logger.error('课表渲染异常', error, {
+      componentStack: info.componentStack,
+    });
   }
 
   render() {

--- a/src/hooks/useThemeChangeStyle.ts
+++ b/src/hooks/useThemeChangeStyle.ts
@@ -2,7 +2,6 @@ import { useIsFocused } from 'expo-router';
 import { useEffect } from 'react';
 import {
   interpolateColor,
-  StyleProps,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
@@ -11,21 +10,28 @@ import {
 import useVisualScheme from '@/store/visualScheme';
 import { ConfigurableThemeNames } from '@/styles/types';
 
+type ColorStyleName = 'backgroundColor' | 'color';
+type ThemeColorStyle = Partial<Record<ColorStyleName, string>>;
+
 const useThemeChangeStyle = (
   configurableThemeName: ConfigurableThemeNames,
-  styleName: keyof StyleProps
+  styleName: ColorStyleName
 ) => {
   const isFocused = useIsFocused();
   const currentStyle = useVisualScheme(state => state.currentStyle);
   const previousColor = useSharedValue(
-    (currentStyle?.[configurableThemeName]?.[styleName] ?? '') as string
+    (currentStyle?.[configurableThemeName] as ThemeColorStyle | undefined)?.[
+      styleName
+    ] ?? ''
   );
   const progress = useSharedValue(0);
 
   // 动态样式
   const animatedStyle = useAnimatedStyle(() => {
-    const currentColor = (currentStyle?.[configurableThemeName]?.[styleName] ??
-      '') as string;
+    const currentColor =
+      (currentStyle?.[configurableThemeName] as ThemeColorStyle | undefined)?.[
+        styleName
+      ] ?? '';
 
     // 如果不是当前页面，直接返回新的颜色值
     if (!isFocused) {
@@ -46,10 +52,12 @@ const useThemeChangeStyle = (
   useEffect(() => {
     'worklet';
     const currentColor =
-      currentStyle?.[configurableThemeName]?.[styleName] ?? '';
+      (currentStyle?.[configurableThemeName] as ThemeColorStyle | undefined)?.[
+        styleName
+      ] ?? '';
     if (previousColor.value !== currentColor) {
       progress.value = withTiming(1, { duration: 400 }, () => {
-        previousColor.value = currentColor as string;
+        previousColor.value = currentColor;
       });
     }
   }, [currentStyle, isFocused]);

--- a/src/modules/courseTable/index.tsx
+++ b/src/modules/courseTable/index.tsx
@@ -209,7 +209,7 @@ const CourseTablePage: FC = () => {
       }
 
       if (parsed.droppedCount > 0) {
-        log.warn(`课表数据已忽略 ${parsed.droppedCount} 条异常课程`);
+        logger.warn(`课表数据已忽略 ${parsed.droppedCount} 条异常课程`);
         Toast.show({
           text: `发现 ${parsed.droppedCount} 条异常课程，已安全忽略`,
           icon: 'fail',
@@ -266,7 +266,7 @@ const CourseTablePage: FC = () => {
       setTimetableStatus(
         useCourse.getState().courses.length > 0 ? 'stale' : 'error'
       );
-      log.error('Failed to retry timetable:', error);
+      logger.error('Failed to retry timetable', error);
       Toast.show({
         text: getTimetableErrorMessage(error),
         icon: 'fail',
@@ -341,7 +341,7 @@ const CourseTablePage: FC = () => {
         targetYear = current.year;
         targetSemester = current.semester;
       } catch (semesterError) {
-        log.error('Failed to initialize semester metadata:', semesterError);
+        logger.error('Failed to initialize semester metadata', semesterError);
       }
 
       if (!targetYear || !targetSemester) {

--- a/src/utils/uploadPicture.ts
+++ b/src/utils/uploadPicture.ts
@@ -64,6 +64,11 @@ async function uploadFileToFeishuBitable(
   fileName: string
 ): Promise<any> {
   try {
+    const parentNode = FIXED_CONFIG.parentNode;
+    if (!parentNode) {
+      throw new Error('未配置反馈附件父节点');
+    }
+
     // 获取文件信息和内容
     const fileInfo = await getFileInfo(fileUri);
 
@@ -73,7 +78,7 @@ async function uploadFileToFeishuBitable(
     // 添加文本字段
     formData.append('file_name', fileName);
     formData.append('parent_type', FIXED_CONFIG.parentType);
-    formData.append('parent_node', FIXED_CONFIG.parentNode);
+    formData.append('parent_node', parentNode);
     formData.append('size', fileInfo.size.toString());
 
     // 计算并添加校验和


### PR DESCRIPTION
Refs #320

## 这次改了什么

- Build Test 使用 `pnpm install --frozen-lockfile`，并直接运行无交互的 `expo prebuild --no-install`。Prebuild 失败时，GitHub Actions 会收到原始的非零退出码。
- 反馈附件上传前检查 `EXPO_PUBLIC_FEEDBACK_PARENT_NODE`。配置缺失时直接报出明确错误，不再把 `undefined` 写入 `FormData` 后继续请求飞书接口。
- 课表错误边界、异常课程警告、重试失败和学期初始化失败统一调用现有的 `logger`，避免异常发生后再次调用不存在的 `log`。
- `useThemeChangeStyle` 只允许读取 `color` 和 `backgroundColor`，并用纯类型转换消除宽泛索引错误。取色、插值、页面焦点判断和 400 ms 动画逻辑均未改动。

## 影响范围

正常配置下，反馈附件上传流程不变；只有缺少 `parentNode` 的错误配置会更早终止。Logger 修改只覆盖原本的警告和错误路径，现有 Toast、状态更新和重试流程保持不变。

主题 Hook 没有新增运行时代码。使用 Babel 分别编译修改前后的文件并规范化输出后，两份 JavaScript 完全一致，因此这部分只收紧 TypeScript 类型，不改变真机执行逻辑。

本地 `pnpm build` 的交互式发布流程没有调整。

## 验证

在 Node 22.14.0、pnpm 11.6.0 下完成：

- `pnpm format:check`
- `pnpm lint`
- `CI=true pnpm exec expo prebuild --no-install`
- 修改前后主题 Hook 的 Babel 编译结果对比
- `git diff --check`

Expo Prebuild 执行成功，且没有产生未提交文件。

完整执行 `pnpm exec tsc --noEmit --pretty false` 后，错误数从 26 个降到 18 个；本 PR 修改的四个源码文件已不再报错。剩余 18 个错误属于 #320 中尚未处理的 TypeScript 基线，本 PR 没有为了让类型检查全绿而扩大修改范围，也暂未把 `typecheck` 加入 CI。

## 尚未覆盖

尚未连接真实后端或执行真机登录、反馈回归。
