### PR TITLE
refactor(request): 共用请求拦截流程并补充回归测试

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Run Format Check
         run: pnpm run format:check
+
+      - name: Run Request Tests
+        run: pnpm run test:request

--- a/docs/api-and-request.md
+++ b/docs/api-and-request.md
@@ -86,12 +86,14 @@ const res = await request.post('/course/note', {
 
 ### 4.2 401 拦截与请求重放机制
 
-在 `src/request/index.ts` 中实现了完整的防抖重试队列：
+`src/request/installRequestInterceptors.ts` 负责两个客户端共用的 token 注入、请求计数和 401 重试流程；各客户端保留自己的 token 读取与刷新方式。
 
-1. 当请求收到 `401 Unauthorized` 时，系统拦截该错误。
-2. 若当前已有刷新 Promise 在进行中，其他 401 请求将等待同一个刷新 Promise，避免同时发起多次刷新调用。
-3. 刷新成功后，更新本地 `shortToken` 缓存，使用新 Token 自动重放原失败请求。
-4. 若刷新失败或长 Token 已过期，系统自动中断队列并重定向用户至 `/auth/login`。
+1. `isToken: false` 跳过自动 token 注入；其余请求读取对应 token，去除首尾空白后写入 `Authorization`。
+2. 首次收到 `401 Unauthorized` 时标记 `_retry`，尝试刷新并重放原请求。重放再次返回 401 时直接拒绝，不再刷新。
+3. 主服务的短 token 刷新仍由 `src/request/index.ts` 管理。并发请求共用正在执行的刷新 Promise；刷新成功后写入 `shortToken`，失败时跳转 `/auth/login`。
+4. 配置 `otherToken` 的请求沿用其 `refresh` 与 `onRefreshError`。反馈客户端没有可用的 `refresh` 时直接返回原 401，不跳转主服务登录页。
+
+重放请求仍会经过请求拦截器，按原有优先级重新读取显式 token 或本地缓存。重放失败不视为刷新失败，不会再次触发 `onRefreshError`。
 
 ---
 
@@ -99,6 +101,17 @@ const res = await request.post('/course/note', {
 
 在 `src/store/currentRequests.ts` 中维护了一个轻量级的内存级请求总线：
 
-- 任何通过 `axiosInstance` 发起的请求在发出时调用 `requestRegister()`（计数 +1）。
-- 在响应或错误返回时调用 `requestComplete()`（计数 -1）。
-- 全局 UI（例如全局下拉刷新指示器、页面 Loading 遮罩）可随时通过订阅 `requestBus` 获取当前应用是否仍有后台网络活动。
+- 两个客户端共用同一个总线，每次进入请求拦截器时调用 `requestRegister()`，增加 `totalRequestNum`。
+- 响应成功或失败时调用 `requestComplete()`，增加 `resolvedRequestNum`；读取 token 失败、尚未发出 HTTP 请求时也会完成计数。
+- 两个计数相等且一秒内没有新请求时，总线将计数归零，并通过 `globalEventBus` 发出 `request_complete` 事件。
+- 401 重放单独计数。主服务通过原始 `axios.get` 发出的短 token 刷新请求不进入这组拦截器，不计入总线。
+
+## 6. 请求层回归测试
+
+使用 Node.js 22 执行：
+
+```bash
+pnpm run test:request
+```
+
+测试通过 `request` 和 `feedbackRequest` 公开入口调用真实 Axios，仅替换 HTTP adapter、原生依赖和服务地址。覆盖查询参数、token 优先级、401 重试、刷新失败回调、登录跳转以及请求计数；不连接真实后端。该命令也在 CI 中执行。

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
+    "test:request": "node --test tests/request.test.mjs",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt",

--- a/src/request/feedbackRequest.ts
+++ b/src/request/feedbackRequest.ts
@@ -34,7 +34,8 @@ async function getStoredFeedbackToken(
 
 installRequestInterceptors(feedbackAxiosInstance, {
   getToken: config => getStoredFeedbackToken(config),
-  getRefresher: config => config?.refresh?.bind(config),
+  getRefresher: config =>
+    config?.refresh ? () => config.refresh() : undefined,
 });
 
 export const feedbackRequest = createRequestClient<FeedbackPaths>(

--- a/src/request/feedbackRequest.ts
+++ b/src/request/feedbackRequest.ts
@@ -2,10 +2,10 @@ import axios, { AxiosInstance } from 'axios';
 import { getItem } from 'expo-secure-store';
 
 import { FEEDBACK_BASE_URL } from '@/constants/BASE_URLS';
-import requestBus from '@/store/currentRequests';
 import { OtherTokenConfig } from '@/types/axios';
 
 import { createRequestClient } from './createRequestClient';
+import { installRequestInterceptors } from './installRequestInterceptors';
 import { paths as FeedbackPaths } from './schema.feedback';
 
 const feedbackAxiosInstance: AxiosInstance = axios.create({
@@ -32,63 +32,10 @@ async function getStoredFeedbackToken(
   throw new Error(`获取 ${config.name} 失败`);
 }
 
-feedbackAxiosInstance.interceptors.request.use(
-  async config => {
-    requestBus.requestRegister();
-
-    if (config.isToken === false) return config;
-
-    try {
-      const token = await getStoredFeedbackToken(config?.otherToken);
-      if (token) {
-        config.headers['Authorization'] = `Bearer ${token.trim()}`;
-      }
-    } catch (err) {
-      return Promise.reject(err);
-    }
-
-    return config;
-  },
-  error => {
-    return Promise.reject(error);
-  }
-);
-
-feedbackAxiosInstance.interceptors.response.use(
-  response => {
-    requestBus.requestComplete();
-
-    if (response.status >= 200 && response.status < 300) {
-      return response;
-    }
-    return Promise.reject(new Error(`Error status code: ${response.status}`));
-  },
-  async error => {
-    requestBus.requestComplete();
-    const originalRequest = error.config;
-
-    if (
-      error.response?.status === 401 &&
-      originalRequest &&
-      !originalRequest._retry
-    ) {
-      originalRequest._retry = true;
-      const tokenConfig = originalRequest?.otherToken;
-      if (tokenConfig?.refresh) {
-        try {
-          const newToken = await tokenConfig.refresh();
-          originalRequest.headers['Authorization'] = `Bearer ${newToken}`;
-          return feedbackAxiosInstance(originalRequest);
-        } catch (refreshError) {
-          tokenConfig.onRefreshError?.(refreshError);
-          return Promise.reject(refreshError);
-        }
-      }
-    }
-
-    return Promise.reject(error);
-  }
-);
+installRequestInterceptors(feedbackAxiosInstance, {
+  getToken: config => getStoredFeedbackToken(config),
+  getRefresher: config => config?.refresh?.bind(config),
+});
 
 export const feedbackRequest = createRequestClient<FeedbackPaths>(
   feedbackAxiosInstance

--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -3,10 +3,10 @@ import { router } from 'expo-router';
 import { getItem, setItem } from 'expo-secure-store';
 
 import { BASE_URL } from '@/constants/BASE_URLS';
-import requestBus from '@/store/currentRequests';
 import { OtherTokenConfig } from '@/types/axios';
 
 import { createRequestClient } from './createRequestClient';
+import { installRequestInterceptors } from './installRequestInterceptors';
 import { paths } from './schema';
 
 const axiosInstance: AxiosInstance = axios.create({
@@ -84,69 +84,12 @@ async function refreshToken(config?: OtherTokenConfig): Promise<string> {
   throw new Error(`${config.name} 未配置 refresh`);
 }
 
-axiosInstance.interceptors.request.use(
-  async config => {
-    requestBus.requestRegister();
-
-    if (config.isToken === false) return config;
-
-    try {
-      const token = await getStoredToken(config?.otherToken);
-      if (token) {
-        config.headers['Authorization'] = `Bearer ${token.trim()}`;
-      }
-    } catch {
-      throw Error('token不存在');
-    }
-
-    return config;
-  },
-  error => {
-    return Promise.reject(error);
-  }
-);
-
-axiosInstance.interceptors.response.use(
-  response => {
-    requestBus.requestComplete();
-
-    if (response.status >= 200 && response.status < 300) {
-      return response;
-    }
-    return Promise.reject(new Error(`Error status code: ${response.status}`));
-  },
-  async error => {
-    requestBus.requestComplete();
-    const originalRequest = error.config;
-
-    if (
-      error.response?.status === 401 &&
-      originalRequest &&
-      !originalRequest._retry
-    ) {
-      originalRequest._retry = true; // 防止无限循环
-
-      const tokenConfig = originalRequest?.otherToken;
-      try {
-        const newToken = await refreshToken(tokenConfig);
-
-        originalRequest.headers['Authorization'] = `Bearer ${newToken}`;
-        return axiosInstance(originalRequest); // 重新发送请求
-      } catch (refreshError) {
-        if (tokenConfig) {
-          tokenConfig.onRefreshError?.(refreshError);
-          return Promise.reject(refreshError);
-        }
-
-        router.replace('/auth/login');
-        return Promise.reject(refreshError);
-      }
-    }
-
-    //   console.error('Error response:', error);
-    return Promise.reject(error);
-  }
-);
+installRequestInterceptors(axiosInstance, {
+  getToken: config => getStoredToken(config),
+  getRefresher: config => () => refreshToken(config),
+  mapTokenError: () => new Error('token不存在'),
+  onDefaultRefreshError: () => router.replace('/auth/login'),
+});
 
 const request = createRequestClient<paths>(axiosInstance);
 

--- a/src/request/installRequestInterceptors.ts
+++ b/src/request/installRequestInterceptors.ts
@@ -1,0 +1,78 @@
+import type { AxiosInstance } from 'axios';
+
+import requestBus from '@/store/currentRequests';
+import type { OtherTokenConfig } from '@/types/axios';
+
+interface TokenPolicy {
+  getToken(config?: OtherTokenConfig): Promise<string>;
+  getRefresher(config?: OtherTokenConfig): (() => Promise<string>) | undefined;
+  mapTokenError?(error: unknown): unknown;
+  onDefaultRefreshError?(error: unknown): void;
+}
+
+export function installRequestInterceptors(
+  instance: AxiosInstance,
+  tokenPolicy: TokenPolicy
+) {
+  instance.interceptors.request.use(async config => {
+    requestBus.requestRegister();
+
+    if (config.isToken === false) return config;
+
+    try {
+      const token = await tokenPolicy.getToken(config.otherToken);
+      if (token) {
+        config.headers['Authorization'] = `Bearer ${token.trim()}`;
+      }
+    } catch (error) {
+      throw tokenPolicy.mapTokenError
+        ? tokenPolicy.mapTokenError(error)
+        : error;
+    }
+
+    return config;
+  });
+
+  instance.interceptors.response.use(
+    response => {
+      requestBus.requestComplete();
+
+      if (response.status >= 200 && response.status < 300) {
+        return response;
+      }
+      return Promise.reject(new Error(`Error status code: ${response.status}`));
+    },
+    async error => {
+      requestBus.requestComplete();
+      const originalRequest = error.config;
+
+      if (
+        error.response?.status === 401 &&
+        originalRequest &&
+        !originalRequest._retry
+      ) {
+        originalRequest._retry = true;
+        const tokenConfig = originalRequest.otherToken;
+        const refresh = tokenPolicy.getRefresher(tokenConfig);
+
+        if (refresh) {
+          try {
+            const newToken = await refresh();
+            originalRequest.headers['Authorization'] = `Bearer ${newToken}`;
+            // Do not await: a failed replay is not a token-refresh failure.
+            return instance(originalRequest);
+          } catch (refreshError) {
+            if (tokenConfig) {
+              tokenConfig.onRefreshError?.(refreshError);
+            } else {
+              tokenPolicy.onDefaultRefreshError?.(refreshError);
+            }
+            return Promise.reject(refreshError);
+          }
+        }
+      }
+
+      return Promise.reject(error);
+    }
+  );
+}

--- a/tests/request.test.mjs
+++ b/tests/request.test.mjs
@@ -1,0 +1,440 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { runInThisContext } from 'node:vm';
+
+import axios from 'axios';
+import ts from 'typescript';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const compiled = new Map();
+
+// Load the real request modules with Node and the existing TypeScript compiler.
+// Only HTTP, native platform dependencies and configured URLs are replaced.
+function loadClients(t, { stored = { shortToken: 'short' }, respond } = {}) {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const storage = new Map(Object.entries(stored));
+  const calls = [];
+  const routes = [];
+  const modules = new Map();
+  const nativeStorage = {
+    getItem: t.mock.fn(key => storage.get(key) ?? null),
+    setItem: t.mock.fn((key, value) => storage.set(key, value)),
+  };
+  const transport = axios.create({
+    adapter: async config => {
+      calls.push(config);
+      const result = (await respond?.(config)) ?? { data: { ok: true } };
+      const response = {
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        data: undefined,
+        config,
+        ...result,
+      };
+      if (config.validateStatus && !config.validateStatus(response.status)) {
+        throw new axios.AxiosError(
+          `HTTP ${response.status}`,
+          'ERR_BAD_RESPONSE',
+          config,
+          undefined,
+          response
+        );
+      }
+      return response;
+    },
+  });
+  const replacements = {
+    axios: transport,
+    'expo-secure-store': nativeStorage,
+    'expo-router': { router: { replace: route => routes.push(route) } },
+    'expo-constants': {},
+    'react-native': { Platform: { OS: 'ios' } },
+    '@/constants/BASE_URLS': {
+      BASE_URL: 'https://main.example',
+      FEEDBACK_BASE_URL: 'https://feedback.example',
+    },
+  };
+
+  function load(filename) {
+    if (modules.has(filename)) return modules.get(filename).exports;
+    if (!compiled.has(filename)) {
+      compiled.set(
+        filename,
+        ts.transpileModule(readFileSync(filename, 'utf8'), {
+          fileName: filename,
+          compilerOptions: {
+            module: ts.ModuleKind.CommonJS,
+            target: ts.ScriptTarget.ES2022,
+            esModuleInterop: true,
+          },
+        }).outputText
+      );
+    }
+    const module = { exports: {} };
+    modules.set(filename, module);
+    const localRequire = name => {
+      if (Object.hasOwn(replacements, name)) return replacements[name];
+      if (!name.startsWith('.') && !name.startsWith('@/')) return require(name);
+      const path = name.startsWith('@/')
+        ? resolve(root, 'src', name.slice(2))
+        : resolve(dirname(filename), name);
+      return load(existsSync(`${path}.ts`) ? `${path}.ts` : `${path}/index.ts`);
+    };
+    runInThisContext(
+      `(function(require, module, exports) {\n${compiled.get(filename)}\n})`,
+      {
+        filename,
+      }
+    )(localRequire, module, module.exports);
+    return module.exports;
+  }
+
+  const clients = load(resolve(root, 'src/request/index.ts'));
+  const bus = load(resolve(root, 'src/store/currentRequests.ts')).default;
+  const events = load(resolve(root, 'src/utils/eventBus.ts')).default;
+  let completeEvents = 0;
+  events.on('request_complete', () => completeEvents++);
+  t.after(() => {
+    assert.equal(bus.resolvedRequestNum, bus.totalRequestNum);
+    t.mock.timers.tick(1000);
+    assert.equal(bus.totalRequestNum, 0);
+    assert.equal(bus.resolvedRequestNum, 0);
+    assert.equal(completeEvents, 1);
+  });
+  return { ...clients, bus, storage, calls, routes, nativeStorage };
+}
+
+for (const name of ['request', 'feedbackRequest']) {
+  test(`${name}: preserves queries, header precedence, URL and response data`, async t => {
+    const h = loadClients(t);
+    const result = await h[name].get(
+      '/records',
+      {
+        query: {
+          ids: ['a b', null, undefined, 'c&d'],
+          omitted: null,
+          missing: undefined,
+          empty: '',
+          zero: 0,
+        },
+        header: { 'X-Source': 'params' },
+      },
+      { isToken: false, headers: { 'X-Source': 'config' } }
+    );
+    assert.deepEqual(result, { ok: true });
+    assert.equal(h.calls[0].url, '/records?ids=a+b&ids=c%26d&empty=&zero=0');
+    assert.equal(h.calls[0].headers['X-Source'], 'config');
+    assert.equal(h.calls[0].headers.Authorization, undefined);
+    assert.equal(
+      h.calls[0].baseURL,
+      name === 'request' ? 'https://main.example' : 'https://feedback.example'
+    );
+    assert.equal(h.nativeStorage.getItem.mock.callCount(), 0);
+  });
+
+  test(`${name}: preserves get/post/put/delete and raw queries`, async t => {
+    const h = loadClients(t);
+    await h[name].get(
+      '/records',
+      { query: 'ids=a%20b&ids=c' },
+      { isToken: false }
+    );
+    await h[name].post('/records', { value: 1 }, { isToken: false });
+    await h[name].put('/records', { value: 2 }, { isToken: false });
+    await h[name].delete(
+      '/records',
+      { query: { id: 'a/b' } },
+      { isToken: false }
+    );
+    assert.deepEqual(
+      h.calls.map(c => [c.method, c.url, c.data]),
+      [
+        ['get', '/records?ids=a%20b&ids=c', undefined],
+        ['post', '/records', '{"value":1}'],
+        ['put', '/records', '{"value":2}'],
+        ['delete', '/records?id=a%2Fb', undefined],
+      ]
+    );
+  });
+
+  for (const source of ['explicit', 'stored', 'refresh']) {
+    test(`${name}: reads ${source} custom token and trims Authorization`, async t => {
+      const h = loadClients(t, {
+        stored: source === 'stored' ? { table: ' stored ' } : {},
+      });
+      const refresh = t.mock.fn(async () => ' refreshed ');
+      await h[name].get('/records', undefined, {
+        otherToken: {
+          name: 'table',
+          token: source === 'explicit' ? ' explicit ' : undefined,
+          refresh,
+        },
+      });
+      assert.equal(
+        h.calls[0].headers.Authorization,
+        `Bearer ${source === 'refresh' ? 'refreshed' : source}`
+      );
+      assert.equal(refresh.mock.callCount(), source === 'refresh' ? 1 : 0);
+      assert.equal(
+        h.nativeStorage.getItem.mock.callCount(),
+        source === 'explicit' ? 0 : 1
+      );
+    });
+  }
+
+  test(`${name}: refreshes once and replays a 401 with the stored replacement`, async t => {
+    const h = loadClients(t, {
+      stored: { table: 'old' },
+      respond: c => ({
+        status: c._retry ? 200 : 401,
+        data: { recovered: true },
+      }),
+    });
+    const refresh = t.mock.fn(async function () {
+      assert.equal(this.name, 'table');
+      h.storage.set('table', 'new');
+      return 'new';
+    });
+    const result = await h[name].get('/records', undefined, {
+      otherToken: { name: 'table', refresh },
+    });
+    assert.deepEqual(result, { recovered: true });
+    assert.equal(h.calls.length, 2);
+    assert.equal(h.calls[1].headers.Authorization, 'Bearer new');
+    assert.equal(refresh.mock.callCount(), 1);
+    assert.equal(h.bus.totalRequestNum, 2);
+  });
+
+  test(`${name}: rejects the second 401 without refreshing again`, async t => {
+    const h = loadClients(t, { respond: () => ({ status: 401 }) });
+    const refresh = t.mock.fn(async () => 'new');
+    const onRefreshError = t.mock.fn();
+    await assert.rejects(
+      h[name].get('/records', undefined, {
+        otherToken: { name: 'table', token: 'fixed', refresh, onRefreshError },
+      }),
+      { message: 'HTTP 401' }
+    );
+    assert.equal(h.calls.length, 2);
+    assert.equal(refresh.mock.callCount(), 1);
+    assert.equal(onRefreshError.mock.callCount(), 0);
+    assert.equal(h.calls[1].headers.Authorization, 'Bearer fixed');
+    assert.deepEqual(h.routes, []);
+  });
+
+  test(`${name}: keeps its error when a custom token cannot be trimmed`, async t => {
+    const h = loadClients(t);
+    await assert.rejects(
+      h[name].get('/records', undefined, {
+        otherToken: { name: 'table', token: 123 },
+      }),
+      name === 'request' ? { message: 'token不存在' } : TypeError
+    );
+    assert.equal(h.calls.length, 0);
+  });
+
+  test(`${name}: keeps its 401 behavior when a custom refresher is missing`, async t => {
+    const h = loadClients(t, { respond: () => ({ status: 401 }) });
+    const onRefreshError = t.mock.fn();
+    await assert.rejects(
+      h[name].get('/records', undefined, {
+        otherToken: { name: 'table', token: 'old', onRefreshError },
+      }),
+      {
+        message: name === 'request' ? 'table 未配置 refresh' : 'HTTP 401',
+      }
+    );
+    assert.equal(onRefreshError.mock.callCount(), name === 'request' ? 1 : 0);
+    assert.equal(h.calls.length, 1);
+    assert.deepEqual(h.routes, []);
+  });
+
+  test(`${name}: custom refresh failure reaches its callback and caller`, async t => {
+    const failure = new Error('refresh failed');
+    const h = loadClients(t, { respond: () => ({ status: 401 }) });
+    const onRefreshError = t.mock.fn();
+    await assert.rejects(
+      h[name].get('/records', undefined, {
+        otherToken: {
+          name: 'table',
+          token: 'old',
+          refresh: async () => {
+            throw failure;
+          },
+          onRefreshError,
+        },
+      }),
+      error => error === failure
+    );
+    assert.equal(onRefreshError.mock.callCount(), 1);
+    assert.equal(onRefreshError.mock.calls[0].arguments[0], failure);
+    assert.equal(h.calls.length, 1);
+    assert.deepEqual(h.routes, []);
+  });
+
+  test(`${name}: token lookup failure completes the request before transport`, async t => {
+    const failure = new Error('storage unavailable');
+    const h = loadClients(t);
+    h.nativeStorage.getItem.mock.mockImplementation(() => {
+      throw failure;
+    });
+    await assert.rejects(
+      h[name].get('/records', undefined, {
+        otherToken: { name: 'table', refresh: async () => 'unused' },
+      }),
+      name === 'request'
+        ? { message: 'token不存在' }
+        : error => error === failure
+    );
+    assert.equal(h.calls.length, 0);
+    assert.equal(h.bus.totalRequestNum, 1);
+  });
+
+  test(`${name}: network and HTTP failures settle counts without retry`, async t => {
+    const networkError = new Error('offline');
+    const h = loadClients(t, {
+      respond: c => {
+        if (c.url === '/offline') throw networkError;
+        return { status: 503 };
+      },
+    });
+    const results = await Promise.allSettled([
+      h[name].get('/offline', undefined, { isToken: false }),
+      h[name].get('/unavailable', undefined, { isToken: false }),
+    ]);
+    assert.equal(results[0].reason, networkError);
+    assert.equal(results[1].reason.response.status, 503);
+    assert.equal(h.calls.length, 2);
+  });
+
+  test(`${name}: keeps the existing non-2xx check after validateStatus`, async t => {
+    const h = loadClients(t, { respond: () => ({ status: 304 }) });
+    await assert.rejects(
+      h[name].get('/records', undefined, {
+        isToken: false,
+        validateStatus: () => true,
+      }),
+      { message: 'Error status code: 304' }
+    );
+    assert.equal(h.calls.length, 1);
+  });
+}
+
+test('request: shares one short-token refresh across concurrent 401s', async t => {
+  let releaseRefresh;
+  const refreshGate = new Promise(resolve => {
+    releaseRefresh = resolve;
+  });
+  let refreshStarted;
+  const started = new Promise(resolve => {
+    refreshStarted = resolve;
+  });
+  const h = loadClients(t, {
+    stored: { shortToken: 'old', longToken: 'long' },
+    respond: async c => {
+      if (c.url.endsWith('/users/refresh_token')) {
+        refreshStarted();
+        await refreshGate;
+        return { headers: { 'x-jwt-token': 'new' } };
+      }
+      return { status: c._retry ? 200 : 401, data: { ok: true } };
+    },
+  });
+  const pending = Promise.all([h.request.get('/one'), h.request.get('/two')]);
+  await started;
+  // Let both rejected requests reach the shared refresh before releasing HTTP.
+  await new Promise(resolve => setImmediate(resolve));
+  releaseRefresh();
+  assert.deepEqual(await pending, [{ ok: true }, { ok: true }]);
+  const refreshCalls = h.calls.filter(c =>
+    c.url.endsWith('/users/refresh_token')
+  );
+  assert.equal(refreshCalls.length, 1);
+  assert.equal(refreshCalls[0].headers.Authorization, 'Bearer long');
+  assert.equal(h.storage.get('shortToken'), 'new');
+  assert.equal(
+    h.calls
+      .filter(c => c._retry)
+      .every(c => c.headers.Authorization === 'Bearer new'),
+    true
+  );
+  assert.equal(h.bus.totalRequestNum, 4);
+});
+
+test('request: missing long token on 401 keeps the login redirect', async t => {
+  const h = loadClients(t, { respond: () => ({ status: 401 }) });
+  await assert.rejects(h.request.get('/records'), {
+    message: '长 token 不存在，跳转登录',
+  });
+  assert.deepEqual(h.routes, ['/auth/login']);
+  assert.equal(h.calls.length, 1);
+});
+
+test('request: missing short token refreshes before sending the request', async t => {
+  const h = loadClients(t, {
+    stored: { longToken: 'long' },
+    respond: c =>
+      c.url.endsWith('/users/refresh_token')
+        ? { status: 201, headers: { 'x-jwt-token': 'new' } }
+        : { data: 'done' },
+  });
+  assert.equal(await h.request.get('/records'), 'done');
+  assert.equal(h.calls[1].headers.Authorization, 'Bearer new');
+  assert.equal(h.bus.totalRequestNum, 1);
+});
+
+test('feedbackRequest: missing otherToken rejects without login navigation', async t => {
+  const h = loadClients(t);
+  await assert.rejects(h.feedbackRequest.get('/records'), {
+    message: '反馈接口未配置 otherToken',
+  });
+  assert.deepEqual(h.routes, []);
+  assert.equal(h.calls.length, 0);
+});
+
+test('feedbackRequest: public 401 without a refresher is not replayed', async t => {
+  const h = loadClients(t, { respond: () => ({ status: 401 }) });
+  await assert.rejects(
+    h.feedbackRequest.get('/records', undefined, { isToken: false }),
+    { message: 'HTTP 401' }
+  );
+  assert.equal(h.calls.length, 1);
+  assert.deepEqual(h.routes, []);
+});
+
+test('both clients share counts and wait for the last pending request', async t => {
+  let releaseMain;
+  const mainGate = new Promise(resolve => {
+    releaseMain = resolve;
+  });
+  let mainStarted;
+  const started = new Promise(resolve => {
+    mainStarted = resolve;
+  });
+  const h = loadClients(t, {
+    respond: async c => {
+      if (c.baseURL === 'https://main.example') {
+        mainStarted();
+        await mainGate;
+      }
+    },
+  });
+  const pending = h.request.get('/records');
+  await started;
+  await h.feedbackRequest.get('/records', undefined, {
+    isToken: false,
+    headers: { Authorization: 'Custom unchanged' },
+  });
+  t.mock.timers.tick(1000);
+  assert.equal(h.bus.totalRequestNum, 2);
+  assert.equal(h.bus.resolvedRequestNum, 1);
+  assert.equal(h.calls[1].headers.Authorization, 'Custom unchanged');
+  releaseMain();
+  await pending;
+});

--- a/tests/request.test.mjs
+++ b/tests/request.test.mjs
@@ -278,6 +278,25 @@ for (const name of ['request', 'feedbackRequest']) {
     assert.deepEqual(h.routes, []);
   });
 
+  test(`${name}: an invalid custom refresher still notifies its error callback`, async t => {
+    const h = loadClients(t, { respond: () => ({ status: 401 }) });
+    const onRefreshError = t.mock.fn();
+    await assert.rejects(
+      h[name].get('/records', undefined, {
+        otherToken: {
+          name: 'table',
+          token: 'old',
+          refresh: 123,
+          onRefreshError,
+        },
+      }),
+      TypeError
+    );
+    assert.equal(onRefreshError.mock.callCount(), 1);
+    assert.equal(h.calls.length, 1);
+    assert.deepEqual(h.routes, []);
+  });
+
   test(`${name}: token lookup failure completes the request before transport`, async t => {
     const failure = new Error('storage unavailable');
     const h = loadClients(t);


### PR DESCRIPTION
Refs #320

## 这次改了什么

- 将 `src/request/index.ts` 与 `feedbackRequest.ts` 重复的 token 注入、请求计数和 401 重试集中到 `installRequestInterceptors.ts`。两个客户端保留各自的 token 读取与刷新方式。
- 增加 `request`、`feedbackRequest` 公开入口的回归测试，覆盖查询参数、header 优先级、token 读取、并发刷新、重试上限、错误回调和两客户端共用计数。提交顺序是先增加测试，再抽出共用流程。
- 新增 `pnpm run test:request` 并接入现有 CI。测试使用 Node.js 内置测试工具和项目已有的 TypeScript 编译器，调用真实 Axios，只替换 HTTP adapter、原生依赖与服务地址，没有新增依赖。
- 更新请求层文档，说明共用拦截器的位置、两个客户端的认证差异和请求计数规则。

## 影响范围

`request`、`feedbackRequest` 的公开方法、服务地址、参数序列化和 API 调用方均未修改。主服务继续共用正在执行的短 token 刷新 Promise；401 后刷新失败时仍跳转 `/auth/login`。

自定义 token 继续使用原有的 `refresh` 和 `onRefreshError`。反馈接口未配置刷新方法时返回原 401，不跳转主服务登录页。单个请求最多重试一次，重放仍经过 token 读取流程；重放的响应失败不会再次触发刷新失败回调。

请求成功、读取 token 失败、网络错误和重试均沿用原来的计数规则。主服务通过原始 Axios 发出的短 token 刷新请求仍不计入请求总线。

本 PR 对应 #320 的请求层共用流程，分支直接基于 `main`，不依赖 #323。

## 验证

在 Node 22.14.0、pnpm 11.6.0 下完成：

- `pnpm run test:request`
- `pnpm run lint`
- `pnpm run format:check`
- `CI=1 pnpm exec expo export --platform ios --platform android --output-dir <临时目录> --max-workers 2`
- `git diff --check`

34 项回归测试全部通过，同一批测试也在重构前的实现上通过。查询数组、空值与特殊字符、认证和重试流程以及请求计数均有覆盖。iOS、Android 的 Metro/Hermes 资源导出成功。

全项目类型检查仍未通过。在同一依赖环境中逐项比较主线与本次修改的 TypeScript 诊断，均为 26 个既有错误，位置和内容一致，本次没有新增类型错误。

## 尚未覆盖

尚未连接真实后端或执行真机登录、反馈回归。
