### PR TITLE
refactor(course): 提取共用课程模型

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,6 +56,7 @@
 2. **业务模块 (`src/modules/`)**：
    - 包含高聚合度的业务逻辑、业务组件与子视图模型。
    - 例如课表视图计算、双向手势画布 `TimetableScrollView` 位于 `src/modules/courseTable/`。
+   - 课程共用模型 `courseType`、`CourseTransferType` 位于 `src/modules/courseTable/types.ts`，供状态、工具、小组件与课程视图使用；视图专用 Props 保留在 `components/courseTable/type.ts`。
 3. **通用 UI 组件 (`src/components/`)**：
    - 纯受控或仅含局部交互状态的 UI 基础设施，无特定业务感知。
 4. **状态仓储 (`src/store/`)**：

--- a/src/hooks/useCourseLiveActivity.ts
+++ b/src/hooks/useCourseLiveActivity.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { AppState, type AppStateStatus } from 'react-native';
 
-import type { courseType } from '@/modules/courseTable/components/courseTable/type';
+import type { courseType } from '@/modules/courseTable/types';
 import useTimeStore from '@/store/time';
 import {
   courseLiveActivity,

--- a/src/modules/courseTable/components/CourseDataForm.tsx
+++ b/src/modules/courseTable/components/CourseDataForm.tsx
@@ -6,7 +6,7 @@ import Image from '@/components/image';
 import Modal from '@/components/modal';
 import Picker from '@/components/picker';
 import MultiPicker from '@/components/picker/multiPicker';
-import { courseType } from '@/modules/courseTable/components/courseTable/type';
+import type { courseType } from '@/modules/courseTable/types';
 import { addCourse } from '@/request/api/course';
 import useCourse from '@/store/course';
 import useTimeStore from '@/store/time';

--- a/src/modules/courseTable/components/courseTable/CourseContent.tsx
+++ b/src/modules/courseTable/components/courseTable/CourseContent.tsx
@@ -9,12 +9,15 @@ import {
   COURSE_VERTICAL_PADDING,
   DAYS_OF_WEEK,
 } from '@/constants/SCHEDULE';
+import type {
+  CourseTransferType,
+  courseType,
+} from '@/modules/courseTable/types';
 import useVisualScheme from '@/store/visualScheme';
 import { componentMap } from '@/themeBasedComponents';
 import { parseClassWhen } from '@/utils/courseRuntime';
 
 import ModalContent from './ModalContent';
-import { CourseTransferType, courseType } from './type';
 
 type CourseContentProps = CourseTransferType & {
   originalData: courseType[];

--- a/src/modules/courseTable/components/courseTable/index.tsx
+++ b/src/modules/courseTable/components/courseTable/index.tsx
@@ -32,6 +32,10 @@ import {
   TIME_SLOTS,
   TIME_WIDTH,
 } from '@/constants/SCHEDULE';
+import type {
+  CourseTransferType,
+  courseType,
+} from '@/modules/courseTable/types';
 import useCourseTableAppearance from '@/store/courseTableAppearance';
 import useVisualScheme from '@/store/visualScheme';
 import { commonColors } from '@/styles/common';
@@ -44,7 +48,7 @@ import { StickyBottom } from './StickyBottom';
 import { StickyLeft } from './StickyLeft';
 import { StickyTop } from './StickyTop';
 import TimetableScrollView from './TimetableScrollView';
-import { CourseTableProps, CourseTransferType, courseType } from './type';
+import type { CourseTableProps } from './type';
 
 const Schedule: React.FC<CourseTableProps> = ({
   data,

--- a/src/modules/courseTable/components/courseTable/type.ts
+++ b/src/modules/courseTable/components/courseTable/type.ts
@@ -6,47 +6,13 @@ import {
 } from 'react-native-gesture-handler';
 import { StyleProps } from 'react-native-reanimated';
 
+import type { courseType } from '@/modules/courseTable/types';
 import type { SemesterOptionBase } from '@/utils/generateSemesterOptions';
-export type courseType = {
-  class_when: string;
-  classname: string;
-  credit: number;
-  day: number;
-  id: string;
-  semester: string;
-  teacher: string;
-  week_duration: string;
-  weeks: number[];
-  where: string;
-  year: string;
-  note?: string;
-  nature?: string;
-  is_official: boolean; // 是否为教务系统课程
-};
 
 export interface CourseTableProps {
   data: courseType[];
   currentWeek: number;
   onTimetableRefresh: (_forceRefresh: boolean) => Promise<void>;
-}
-
-// 课程中间类型,比 courseType 增加 rowIndex 和 colIndex
-export interface CourseTransferType {
-  id: string;
-  courseName: string;
-  teacher: string;
-  classroom: string;
-  timeSpan: number;
-  rowIndex: number;
-  colIndex: number;
-  date: string;
-  isThisWeek: boolean;
-  week_duration: string;
-  credit: number;
-  class_when: string;
-  weeks: number[]; // 添加 weeks 字段
-  note?: string; // 添加 note 字段
-  is_official: boolean; // 是否为教务系统课程
 }
 
 export type SemesterOption = SemesterOptionBase;

--- a/src/modules/courseTable/types.ts
+++ b/src/modules/courseTable/types.ts
@@ -1,0 +1,35 @@
+export type courseType = {
+  class_when: string;
+  classname: string;
+  credit: number;
+  day: number;
+  id: string;
+  semester: string;
+  teacher: string;
+  week_duration: string;
+  weeks: number[];
+  where: string;
+  year: string;
+  note?: string;
+  nature?: string;
+  is_official: boolean; // 是否为教务系统课程
+};
+
+// 课程中间类型,比 courseType 增加 rowIndex 和 colIndex
+export interface CourseTransferType {
+  id: string;
+  courseName: string;
+  teacher: string;
+  classroom: string;
+  timeSpan: number;
+  rowIndex: number;
+  colIndex: number;
+  date: string;
+  isThisWeek: boolean;
+  week_duration: string;
+  credit: number;
+  class_when: string;
+  weeks: number[]; // 添加 weeks 字段
+  note?: string; // 添加 note 字段
+  is_official: boolean; // 是否为教务系统课程
+}

--- a/src/modules/setting/components/otherStyle.tsx
+++ b/src/modules/setting/components/otherStyle.tsx
@@ -23,7 +23,7 @@ import Toast from '@/components/toast';
 import { default as ThemeBasedView } from '@/components/view';
 import { PERMISSION_PURPOSES } from '@/constants/PERMISSIONS';
 import { COURSE_ITEM_WIDTH, DAYS_OF_WEEK } from '@/constants/SCHEDULE';
-import { CourseTransferType } from '@/modules/courseTable/components/courseTable/type';
+import type { CourseTransferType } from '@/modules/courseTable/types';
 import useCourseTableAppearance from '@/store/courseTableAppearance';
 import useVisualScheme from '@/store/visualScheme';
 import { commonColors } from '@/styles/common';

--- a/src/store/course.ts
+++ b/src/store/course.ts
@@ -2,7 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
-import type { courseType } from '@/modules/courseTable/components/courseTable/type';
+import type { courseType } from '@/modules/courseTable/types';
 import {
   getCourseScopeKey,
   isValidCourseScope,

--- a/src/themeBasedComponents/android/courseItem.tsx
+++ b/src/themeBasedComponents/android/courseItem.tsx
@@ -7,7 +7,7 @@ import {
   COURSE_ITEM_HEIGHT,
   ITEM_COLORS,
 } from '@/constants/SCHEDULE';
-import { CourseTransferType } from '@/modules/courseTable/components/courseTable/type';
+import type { CourseTransferType } from '@/modules/courseTable/types';
 
 const CourseItem: React.FC<CourseTransferType> = props => {
   const { teacher, courseName, classroom, timeSpan, date, isThisWeek } = props;

--- a/src/themeBasedComponents/ios/courseItem.tsx
+++ b/src/themeBasedComponents/ios/courseItem.tsx
@@ -6,7 +6,7 @@ import {
   COURSE_ITEM_HEIGHT,
   ITEM_COLORS,
 } from '@/constants/SCHEDULE';
-import { CourseTransferType } from '@/modules/courseTable/components/courseTable/type';
+import type { CourseTransferType } from '@/modules/courseTable/types';
 import useVisualScheme from '@/store/visualScheme';
 
 const CourseItem: React.FC<CourseTransferType> = props => {

--- a/src/utils/courseData.ts
+++ b/src/utils/courseData.ts
@@ -1,4 +1,4 @@
-import type { courseType } from '@/modules/courseTable/components/courseTable/type';
+import type { courseType } from '@/modules/courseTable/types';
 import { parseClassWhen } from '@/utils/courseRuntime';
 
 const MAX_REASONABLE_WEEK = 60;

--- a/src/utils/courseRuntime.ts
+++ b/src/utils/courseRuntime.ts
@@ -1,4 +1,4 @@
-import type { courseType } from '@/modules/courseTable/components/courseTable/type';
+import type { courseType } from '@/modules/courseTable/types';
 
 type SectionTimeTuple = [hour: number, minute: number];
 

--- a/src/utils/updateWidget.ts
+++ b/src/utils/updateWidget.ts
@@ -1,7 +1,7 @@
 import { ExtensionStorage } from '@bacons/apple-targets';
 import { Platform } from 'react-native';
 
-import type { courseType } from '@/modules/courseTable/components/courseTable/type';
+import type { courseType } from '@/modules/courseTable/types';
 import useTimeStore from '@/store/time';
 import {
   buildAndroidWidgetCourseData,


### PR DESCRIPTION
Refs #320

## 这次改了什么

- 将 `courseType`、`CourseTransferType` 从视图目录移到 `src/modules/courseTable/types.ts`，保留全部字段、字段名和可选性。
- 更新课程 store、工具函数、实时活动 Hook、课程表单、课表、外观预览和两端课程卡片的引用，统一使用 `import type`。
- `components/courseTable/type.ts` 保留视图 Props 和交互参数类型；架构文档补充模型与视图类型的存放位置。

## 影响范围

这是类型定义和导入路径的整理，不修改运行时代码。课程请求、缓存结构、周次计算、小组件数据格式、课程显示和截图行为均未调整，也没有给旧路径增加兼容转发。

本 PR 只处理 #320 的课程共用模型部分，不关闭整个 Issue。后续课表布局与背景渲染的整理会基于这个分支单独提交。

## 验证

在 Node 22.14.0、pnpm 11.6.0 下完成：

- `pnpm run lint`、`pnpm run format:check`、`git diff --check`。
- 使用项目 Babel 配置分别按 iOS、Android 转译：12 个修改过的源码文件与 `31822db` 主线版本生成的 JavaScript 完全一致。
- 比对 TypeScript 声明，确认两个模型未改变；比对编译器诊断，主线和本分支均为 26 个错误，文件、错误码和消息一致，没有新增类型错误。
- 扫描 283 个源码文件的静态导入：没有循环依赖，也没有继续从视图类型文件导入这两个模型的调用方。
- `expo export --platform ios`、`expo export --platform android` 均成功生成 Hermes bundle。

## 尚未覆盖

未做真机回归或原生安装包构建。导出时未配置 `.env` 和 `JPUSH_APP_KEY`，因此不代表推送等依赖环境配置的功能已验证。主线已有的 26 个类型错误不在本 PR 中修复。
